### PR TITLE
Add example value for field "gameID"

### DIFF
--- a/chess/3-web-api/web-api.md
+++ b/chess/3-web-api/web-api.md
@@ -73,7 +73,7 @@ Note that `whiteUsername` and `blackUsername` may be `null`.
 | **URL path**         | `/game`                                                                                  |
 | **HTTP Method**      | `GET`                                                                                    |
 | **Headers**          | `authorization: <authToken>`                                                             |
-| **Success response** | [200] `{ "games": ["gameID":, "whiteUsername":"", "blackUsername":"", "gameName:""} ]}`  |
+| **Success response** | [200] `{ "games": ["gameID": 1234, "whiteUsername":"", "blackUsername":"", "gameName:""} ]}`  |
 | **Failure response** | [401] `{ "message": "Error: unauthorized" }`                                             |
 | **Failure response** | [500] `{ "message": "Error: description" }`                                              |
 


### PR DESCRIPTION
All other instances of `"gameID"` in the specs give an integer example value, this proposed change adds an example to an instance missing a value