### PR TITLE
remove `userID` from the User model example

### DIFF
--- a/chess/3-web-api/web-api.md
+++ b/chess/3-web-api/web-api.md
@@ -122,7 +122,6 @@ Previously, you created a `chess` package that contains the model classes that r
 
 | Field    | Type   |
 | -------- | ------ |
-| userID   | int    |
 | username | String |
 | password | String |
 | email    | String |


### PR DESCRIPTION
`userID` does not seem to be used anywhere else in the project