### PR TITLE
fix ChessBoardTests addGetPiece

### DIFF
--- a/chess/1-chess-game/starter-code/passoffTests/chessTests/ChessBoardTests.java
+++ b/chess/1-chess-game/starter-code/passoffTests/chessTests/ChessBoardTests.java
@@ -18,13 +18,15 @@ public class ChessBoardTests {
     @Test
     @DisplayName("Add and Get Piece")
     public void getAddPiece() {
-        ChessPosition position = getNewPosition(4, 4);
+        ChessPosition addPosition = getNewPosition(4, 4);
         ChessPiece piece = getNewPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.BISHOP);
 
-        board.addPiece(position, piece);
+        board.addPiece(addPosition, piece);
 
-        ChessPiece foundPiece = board.getPiece(position);
+        ChessPosition getPosition = getNewPosition(4, 4);
+        ChessPiece foundPiece = board.getPiece(getPosition);
 
+        Assertions.assertNotNull(foundPiece, "Could not find added piece");
         Assertions.assertEquals(piece.getPieceType(), foundPiece.getPieceType(),
                 "ChessPiece returned by getPiece had the wrong piece type");
         Assertions.assertEquals(piece.getTeamColor(), foundPiece.getTeamColor(),


### PR DESCRIPTION
The add and get piece test in ChessBoardTests used the same ChessPosition for both add and get. I've seen students pass this test and assume everything is well and then get really confused why resetBoard fails because of their equals and/or hashcode not working. Using a different but equals object should fix this