### PR TITLE
remove 'Override Methods' from the instructions

### DIFF
--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -66,7 +66,7 @@ The Tests in ChessExtraCredit are for the `Castling` and `En Passant` moves. Suc
 
 To run the tests, you can click the play icon next to an individual test, or you can right click on a package or class and select `Run` or `Run Tests in …`
 
-In order for the tests to pass, you are required to override the `.equals()` and `.hashCode()` methods in your ChessMove implementation and your ChessPosition implementation. To do this automatically in IntelliJ, select Code > Generate... > equals() and hashCode(). The default methods provided by IntelliJ should suffice. The `.equals()` and `.hashCode()` methods need to be more than merely a call to `super()`, and using 'Generate...' should do this correctly. Note, you must have already have finished implementing these classes before generating these methods.
+In order for the tests to pass, you are required to override the `.equals()` and `.hashCode()` methods in your ChessMove implementation and your ChessPosition implementation. To do this automatically in IntelliJ, select Code > Generate... > equals() and hashCode(). The default methods provided by IntelliJ should suffice. The `.equals()` and `.hashCode()` methods need to be more than merely a call to `super()`, and using 'Generate...' should do this correctly. Note, you must have already have finished implementing these classes before IntelliJ will be able to generate these methods.
 
 NOTE: Debugging is often easier if you override the .toString() method in your ChessMove implementation (and possibly ChessPosition implementation). This is not required, but you may want to consider it. The default methods provided by IntelliJ are better than nothing, but you may wish to write your own .toString() method for easiest debugging.
 

--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -66,7 +66,7 @@ The Tests in ChessExtraCredit are for the `Castling` and `En Passant` moves. Suc
 
 To run the tests, you can click the play icon next to an individual test, or you can right click on a package or class and select `Run` or `Run Tests in …`
 
-In order for the tests to pass, you are required to override the `.equals()` and `.hashCode()` methods in your ChessMove implementation and your ChessPosition implementation. To do this automatically in IntelliJ, select Code > Generate... > equals() and hashCode(). The default methods provided by IntelliJ should suffice. The `.equals()` and `.hashCode()` methods need to be more than merely a call to `super()`, and using 'Generate...' should do this correctly.
+In order for the tests to pass, you are required to override the `.equals()` and `.hashCode()` methods in your ChessMove implementation and your ChessPosition implementation. To do this automatically in IntelliJ, select Code > Generate... > equals() and hashCode(). The default methods provided by IntelliJ should suffice. The `.equals()` and `.hashCode()` methods need to be more than merely a call to `super()`, and using 'Generate...' should do this correctly. Note, you must have already have finished implementing these classes before generating these methods.
 
 NOTE: Debugging is often easier if you override the .toString() method in your ChessMove implementation (and possibly ChessPosition implementation). This is not required, but you may want to consider it. The default methods provided by IntelliJ are better than nothing, but you may wish to write your own .toString() method for easiest debugging.
 

--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -66,7 +66,7 @@ The Tests in ChessExtraCredit are for the `Castling` and `En Passant` moves. Suc
 
 To run the tests, you can click the play icon next to an individual test, or you can right click on a package or class and select `Run` or `Run Tests in …`
 
-NOTE: In order for the tests to pass, you are required to override the `.equals()` and `.hashCode()` methods in your ChessMove implementation and your ChessPosition implementation. To do this automatically in IntelliJ, select Code > Generate... > Override Methods and then select equals and hashCode. The default methods provided by IntelliJ should suffice AS LONG AS you choose 'Generate...' from the Code menu rather than 'Override Methods...'. The `.equals()` and `.hashCode()` methods need to be more than merely a call to `super()`, and using 'Generate...' should fix that.
+In order for the tests to pass, you are required to override the `.equals()` and `.hashCode()` methods in your ChessMove implementation and your ChessPosition implementation. To do this automatically in IntelliJ, select Code > Generate... > equals() and hashCode(). The default methods provided by IntelliJ should suffice. The `.equals()` and `.hashCode()` methods need to be more than merely a call to `super()`, and using 'Generate...' should do this correctly.
 
 NOTE: Debugging is often easier if you override the .toString() method in your ChessMove implementation (and possibly ChessPosition implementation). This is not required, but you may want to consider it. The default methods provided by IntelliJ are better than nothing, but you may wish to write your own .toString() method for easiest debugging.
 


### PR DESCRIPTION
The instructions for overriding `equals` and `hashCode` currently mention selecting "Override Methods" from the Code -> Generate menu, but this just creates code that  calls the super methods.

This change removes mention of "Override Methods" altogether and corrects which sub-menu choice should be selected