### PR TITLE
Update instructions for passing of service class test cases

### DIFF
--- a/chess/3-web-api/web-api.md
+++ b/chess/3-web-api/web-api.md
@@ -271,7 +271,7 @@ For this phase the TAs will grade the quality of your project's source code. The
 
 To pass off this assignment, meet with a TA and demonstrate that your code passes the provided test cases and that your test web page loads correctly. You must pass this part to recieve credit for any part of the assignment.
 
-During the pass off, the TA will check the test cases your wrote for the Services classes pass and grade them accoridng to the rubric.
+After checking the above, the TA will run and review the test cases your wrote for the Services classes pass and grade them accoridng to the rubric.
 
 After you pass off your project with a TA, you should immediately submit your project source code for grading. Your grade on the project will be determined by the date you submitted your source code after passing off, not the date that you passed off. If we never receive your source code, you will not receive credit for the assignment. Here are the instructions for submitting your project source code:
 

--- a/chess/3-web-api/web-api.md
+++ b/chess/3-web-api/web-api.md
@@ -271,7 +271,7 @@ For this phase the TAs will grade the quality of your project's source code. The
 
 To pass off this assignment, meet with a TA and demonstrate that your code passes the provided test cases and that your test web page loads correctly. You must pass this part to recieve credit for any part of the assignment.
 
-After checking the above, the TA will run and review the test cases your wrote for the Services classes pass and grade them accoridng to the rubric.
+After checking the above, the TA will run and review the test cases your wrote for the Services classes and grade them accoridng to the rubric.
 
 After you pass off your project with a TA, you should immediately submit your project source code for grading. Your grade on the project will be determined by the date you submitted your source code after passing off, not the date that you passed off. If we never receive your source code, you will not receive credit for the assignment. Here are the instructions for submitting your project source code:
 

--- a/chess/3-web-api/web-api.md
+++ b/chess/3-web-api/web-api.md
@@ -269,15 +269,15 @@ For this phase the TAs will grade the quality of your project's source code. The
 
 ## Pass Off, Submission, and Grading
 
-To pass off this assignment, meet with a TA and demonstrate that your code passes the provided test cases.
+To pass off this assignment, meet with a TA and demonstrate that your code passes the provided test cases and that your test web page loads correctly. You must pass this part to recieve credit for any part of the assignment.
+
+During the pass off, the TA will check the test cases your wrote for the Services classes pass and grade them accoridng to the rubric.
 
 After you pass off your project with a TA, you should immediately submit your project source code for grading. Your grade on the project will be determined by the date you submitted your source code after passing off, not the date that you passed off. If we never receive your source code, you will not receive credit for the assignment. Here are the instructions for submitting your project source code:
 
 - In Intellij, navigate to the "Build" menu at the top of the screen and select "Clean Project" to remove auto-generated build files (if this option is not available, you can skip this step).
 - Create a ZIP file containing your whole project folder (not just the Java source files).
 - Submit your ZIP file on Canvas under the `Chess Web API` assignment.
-- To demonstrate that your test cases execute successfully, you should run your unit tests inside Intellij and take a screenshot of the successful test results displayed by Intellij. Please take one screenshot that shows the result of all of your tests passing. The tests used for the screenshot must be the same as the ones submitted in the Code Quality assignment ZIP file.
-- Submit your screenshot under the `Chess Web API` assignment on Canvas. The screenshot is submitted separately from your code ZIP file.
 
 ### Grading Rubric
 


### PR DESCRIPTION
We decided to include grading the unit tests as part of the live pass off, so this aligns the pass off instructions with that.

Note, my understanding is that the automated test cases and the test web page are required before receiving any points for any part of the rubric (so pass/fail), but the student-made test cases are not. This would have the following implications (non-exhaustive):

1. A student passes off all automated tests and the test web page, but did not write any service unit tests
    a. They would get 125/150 for the live portion of the pass off
    b. They would not be able to pass off again, even if they went back and wrote service unit tests
2. A student fails some automated tests and fails the test web page and had not written any service unit tests
    a. They would not pass, but would be able to rejoin the help queue later to pass off again
    b. In this time, they could choose to write their service class unit tests

If my understanding is correct, then please review the new wording to make sure I expressed it clearly