### PR TITLE
Replace Outdated Setup Instructions

### DIFF
--- a/chess/chess.md
+++ b/chess/chess.md
@@ -14,14 +14,9 @@ We use the game of chess to help you develop and demonstrate mastery during this
 | 5. Pregame       | [doc](5-pregame/getting-started.md)     | [doc](5-pregame/pregame.md)             | [dir](5-pregame/starter-code)     | Creating an command line interface (CLI) for the chess client. |
 | 6. Gameplay      | [doc](6-gameplay/getting-started.md)    | [doc](6-gameplay/gameplay.md)           | [dir](6-gameplay/starter-code)    | Implementing gameplay with multiple players.                   |
 
-## Starter Code
+## Getting Started
 
-⚠ Each phase of the project comes with `starter code`. In order to make it easy to copy the starter files to your personal project repository, you should clone the course repository to your development environment.
-
-```sh
-git clone https://github.com/softwareconstruction240/softwareconstruction.git
-
-```
+The setup process for this project has been streamlined. The instructions are contained in the [Chess GitHub Repository](chess-github-repository/chess-github-repository.md) document.
 
 ## GitHub Commits
 

--- a/instruction/java-fundamentals/java-fundamentals.md
+++ b/instruction/java-fundamentals/java-fundamentals.md
@@ -158,7 +158,7 @@ public class Person {
 }
 ```
 
-You create an object instance of a class with the `new` operator. This allocated the memory on the heap for the object. That memory is cleaned up once the last reference to the object goes out of scope.
+You create an object instance of a class with the `new` operator. This allocates the memory on the heap for the object. That memory is cleaned up once the last reference to the object goes out of scope.
 
 ```java
 var inventor = new Person("James Gosling");


### PR DESCRIPTION
Old instructions from last semester were instructing students to clone the entire repo. Those instructions have been replaced with a reference to the new instructions which live on a different page.