### PR TITLE
Fix Server.java: make compatible with Windows file paths and add clarification

### DIFF
--- a/chess/4-database/starter-code/serverTests/PersistenceTests.java
+++ b/chess/4-database/starter-code/serverTests/PersistenceTests.java
@@ -58,6 +58,9 @@ public class PersistenceTests {
 
         // Restart the server to make sure it actually is persisted.
         stopServer();
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException ignored) {}
         startServer();
 
         //list games using the auth


### PR DESCRIPTION
## Add Windows Compatibility
Java's `Paths.get()` doesn't support colons in the filepath (for example, C:/), so `Server.java` was rewritten to support Windows users. `Spark.staticFiles` references the resources directory, so no instructions need modification.

## Add Clarification
Add a tip regarding opening a project in IntelliJ rather than creating a new one to avoid setup issues.