### PR TITLE
fix(chess4) bad dependency version number

### DIFF
--- a/chess/4-database/getting-started.md
+++ b/chess/4-database/getting-started.md
@@ -30,7 +30,7 @@ This should result in the following additions to your project.
 
 Add the dependency for the MySQL driver and BCrypt. Associate them with your `server` module.
 
-- mysql:mysql-connector-java:8.0.2
+- mysql:mysql-connector-java:8.0.30
 
   - Scope: Compile
 


### PR DESCRIPTION
## Overview
The old version of the phase 4 getting started told students to use a nonexistent version (`mysql:mysql-connector-java:8.0.2`) which results in an error shown below. I believe the document is simply missing an additional digit because `mysql:mysql-connector-java:8.0.20` is a valid version that will download. However, after checking with @pawlh, we discovered that the pass-off tests are actually using a more advanced version. Therefore, we're requested to update the instructions to show the same version currently used by the pass-off tests.

## Images
Screenshot of the Error:
<img width="517" alt="image" src="https://github.com/softwareconstruction240/softwareconstruction/assets/19808440/a75478cd-0288-4b04-909d-979dd8ad48b5">
_NOTE: In this screenshot, it shows `mysql` because I had installed it during testing._

Screenshot of success (when using the correct version number):
<img width="317" alt="image" src="https://github.com/softwareconstruction240/softwareconstruction/assets/19808440/87568e30-0777-4de0-8b6d-04cfba4926ae">

