### PR TITLE
Add time buffer to persistence test for slower machines

### DIFF
--- a/chess/4-database/starter-code/serverTests/PersistenceTests.java
+++ b/chess/4-database/starter-code/serverTests/PersistenceTests.java
@@ -58,6 +58,9 @@ public class PersistenceTests {
 
         // Restart the server to make sure it actually is persisted.
         stopServer();
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException ignored) {}
         startServer();
 
         //list games using the auth


### PR DESCRIPTION
For slower machines, issues arise with stopping the server and immediately running the same instance. I added a line to let the process sleep for 100 milliseconds before restarting the server. 100 ms should be plenty of time, mine worked down to around 8.