### PR TITLE
Added a test to check if the starting position is blank on a move

### DIFF
--- a/chess/1-chess-game/starter-code/passoffTests/chessTests/ChessGameTests.java
+++ b/chess/1-chess-game/starter-code/passoffTests/chessTests/ChessGameTests.java
@@ -186,6 +186,9 @@ public class ChessGameTests {
         Assertions.assertThrows(InvalidMoveException.class, () -> game.makeMove(
                 getNewMove(getNewPosition(1, 1), getNewPosition(4, 1), null)));
 
+        //starting position does not have a piece
+        Assertions.assertThrows(InvalidMoveException.class, () -> game.makeMove(
+                getNewMove(getNewPosition(4, 4), getNewPosition(4, 5), null)));
 
         game.makeMove(getNewMove(getNewPosition(1, 1), getNewPosition(2, 1), null));
         Assertions.assertEquals(game.getBoard(),


### PR DESCRIPTION
For the chess game tests there was a situation that was not originally tested. If someone was to pick a starting position for a move and that position was a blank square then weird things could potentially happen. Most likely the code would crash with a null pointer exception. This test makes sure that students have added a check to see if the starting position has an actual piece. If they find a blank square they should throw a invalid move exception. 