### PR TITLE
Validate that moves in ArrayList are all unique (Phase 1)

### DIFF
--- a/chess/1-chess-game/starter-code/passoffTests/chessTests/ChessGameTests.java
+++ b/chess/1-chess-game/starter-code/passoffTests/chessTests/ChessGameTests.java
@@ -777,7 +777,9 @@ public class ChessGameTests {
 
 
     private void assertMoves(ChessGame game, Set<ChessMove> validMoves, ChessPosition position) {
-        var actualMoves = new HashSet<>(game.validMoves(position));
+        var generatedMoves = game.validMoves(position);
+        var actualMoves = new HashSet<>(generatedMoves);
+        Assertions.assertEquals(generatedMoves.size(), actualMoves.size(), "Duplicate move");
         Assertions.assertEquals(validMoves, actualMoves,
                 "ChessGame validMoves did not return the correct moves");
     }


### PR DESCRIPTION
## Description
While uncommon an uncommon issue, without this adjustment, students may be accidentally adding the same move into their array list multiple times, and it would pass. If this is the case, then the test case should fail and point out their mistake so they can clean up their move logic.

## Notes
Requesting to merge into the `2024winter` branch to avoid confusion from multiple versions of the test cases this year.

This PR applies a change similar to the one already merged as softwareconstruction240/chess#4. Note that the change is required in two different places because the Phase 1 starter code is in a different location than the Phase 0 starter code (This is the topic of softwareconstruction240/chess#5).