### PR TITLE
Update chess-moves.md

### DIFF
--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -69,7 +69,7 @@ public enum PieceType {
 
 #### Key Methods
 
-- **pieceMoves**: This method is similar to `ChessGame.validMoves`, except it does not honor whose turn it is or check if the king is being attacked. This method does account for enemy and friendly pieces blocking movement paths. The `pieceMoves` method will need to take into account the type of piece, and the location of other pieces on the board.
+- **pieceMoves**: This method is similar to `ChessGame.validMoves`, except it does not check if the king is being attacked. This method does account for enemy and friendly pieces blocking movement paths. The `pieceMoves` method will need to take into account the type of piece, and the location of other pieces on the board.
 
 ### ChessMove
 


### PR DESCRIPTION
The validMoves method fails when you have it honor who's team it is.