### PR TITLE
enhance(chess4) persistence test to actually use the database

### DIFF
--- a/chess/4-database/starter-code/serverTests/PersistenceTests.java
+++ b/chess/4-database/starter-code/serverTests/PersistenceTests.java
@@ -65,7 +65,7 @@ public class PersistenceTests {
 
         Assertions.assertTrue(initialRowCount < getDatabaseRows(), "No new data added to database");
 
-        // Test that we can read the data after a restart.
+        // Test that we can read the data after a restart
         stopServer();
         startServer();
 
@@ -78,7 +78,7 @@ public class PersistenceTests {
         Assertions.assertEquals(game1.gameID, createResult.gameID);
         Assertions.assertEquals(createRequest.gameName, game1.gameName, "Game name changed after restart");
         Assertions.assertEquals(registerRequest.username, game1.whiteUsername,
-                "White player user changed after restart");
+                "White player username changed after restart");
 
         //test that we can still log in
         TestModels.TestLoginRequest loginRequest = new TestModels.TestLoginRequest();

--- a/chess/4-database/starter-code/serverTests/PersistenceTests.java
+++ b/chess/4-database/starter-code/serverTests/PersistenceTests.java
@@ -7,6 +7,12 @@ import passoffTests.testClasses.TestException;
 import passoffTests.testClasses.TestModels;
 import server.Server;
 
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
 
 public class PersistenceTests {
 
@@ -33,11 +39,10 @@ public class PersistenceTests {
         serverFacade = new TestServerFacade("localhost", Integer.toString(port));
     }
 
-
     @Test
     @DisplayName("Persistence Test")
     public void persistenceTest() throws TestException {
-        validateDatabase(0, "Database not empty at start");
+        var initialRowCount = getDatabaseRows();
 
         TestModels.TestRegisterRequest registerRequest = new TestModels.TestRegisterRequest();
         registerRequest.username = "ExistingUser";
@@ -58,13 +63,11 @@ public class PersistenceTests {
         joinRequest.playerColor = ChessGame.TeamColor.WHITE;
         serverFacade.verifyJoinPlayer(joinRequest, auth);
 
-        validateDatabase(3, "Database not populate after game play");
+        Assertions.assertTrue(initialRowCount < getDatabaseRows(), "No new data added to database");
 
-        // Restart the server to make sure it actually is persisted.
+        // Test that we can read the data after a restart.
         stopServer();
         startServer();
-
-        validateDatabase(3, "Database not populated after restart");
 
         //list games using the auth
         TestModels.TestListResult listResult = serverFacade.listGames(auth);
@@ -75,7 +78,7 @@ public class PersistenceTests {
         Assertions.assertEquals(game1.gameID, createResult.gameID);
         Assertions.assertEquals(createRequest.gameName, game1.gameName, "Game name changed after restart");
         Assertions.assertEquals(registerRequest.username, game1.whiteUsername,
-                "White player username changed after restart");
+                "White player user changed after restart");
 
         //test that we can still log in
         TestModels.TestLoginRequest loginRequest = new TestModels.TestLoginRequest();
@@ -86,8 +89,8 @@ public class PersistenceTests {
     }
 
 
-    private void validateDatabase(int expectedRows, String errorMsg) {
-        int actualRows = 0;
+    private int getDatabaseRows() {
+        int rows = 0;
         try {
             Class<?> clazz = Class.forName("dataAccess.DatabaseManager");
             Method getConnectionMethod = clazz.getDeclaredMethod("getConnection");
@@ -95,21 +98,42 @@ public class PersistenceTests {
 
             Object obj = clazz.getDeclaredConstructor().newInstance();
             try (Connection conn = (Connection) getConnectionMethod.invoke(obj);) {
-                try (var preparedStatement = conn.prepareStatement("SELECT NAME, NUM_ROWS FROM INFORMATION_SCHEMA.INNODB_TABLESTATS WHERE NAME LIKE CONCAT(DATABASE(), '%')")) {
-                    try (var rs = preparedStatement.executeQuery()) {
-                        while (rs.next()) {
-                            var table = rs.getString("NAME");
-                            var count = rs.getInt("NUM_ROWS");
-                            actualRows += count;
+                try (var statement = conn.createStatement()) {
+                    for (String table : getTables(conn)) {
+                        var sql = "SELECT count(*) FROM " + table;
+                        try (var resultSet = statement.executeQuery(sql)) {
+                            if (resultSet.next()) {
+                                rows += resultSet.getInt(1);
+                            }
                         }
                     }
                 }
+
             }
         } catch (Exception ex) {
-            Assertions.fail("Unable to load database in order to verify persistence");
+            Assertions.fail("Unable to load database in order to verify persistence. Are you using dataAccess.DatabaseManager to set your credentials?");
         }
 
-        Assertions.assertEquals(expectedRows, actualRows, errorMsg);
-    }   
+        return rows;
+    }
+
+    private List<String> getTables(Connection conn) throws SQLException {
+        String sql = """
+                    SELECT table_name
+                    FROM information_schema.tables
+                    WHERE table_schema = DATABASE();
+                """;
+
+        List<String> tableNames = new ArrayList<>();
+        try (var preparedStatement = conn.prepareStatement(sql)) {
+            try (var resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    tableNames.add(resultSet.getString(1));
+                }
+            }
+        }
+
+        return tableNames;
+    }
 
 }


### PR DESCRIPTION
We previously modified the chess server and tests so that it could be automatically started and stopped by the tests. In the case where a user is storing their data in any other location that is not cleaned up when the server restarts the current test cannot distinguish if it is stored in a database or in static memory.

This is an attempt to solve this problem by using the supplied `dataAccess.ServerManager` class to connect to their database and see if records are being cleared out and created.