### PR TITLE
Fixed code in Petshop server that reads the db.properties file to work on Windows.

### DIFF
--- a/petshop/server/src/main/dataaccess/DatabaseManager.java
+++ b/petshop/server/src/main/dataaccess/DatabaseManager.java
@@ -2,9 +2,7 @@ package dataaccess;
 
 import exception.ResponseException;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.nio.file.Paths;
+import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -23,9 +21,7 @@ public class DatabaseManager {
      */
     static {
         try {
-            var propsPath = Paths.get(DatabaseManager.class.getProtectionDomain().getCodeSource().getLocation().getPath(), "db.properties");
-            var propsFile = new File(propsPath.toString());
-            try (var in = new FileInputStream(propsFile)) {
+            try (InputStream in = DatabaseManager.class.getClassLoader().getResourceAsStream("db.properties")) {
                 Properties props = new Properties();
                 props.load(in);
                 databaseName = props.getProperty("db.name");


### PR DESCRIPTION
The Petshop code that reads db.properties was not working on Windows due to the "C:" drive name in the value returned by DatabaseManager.class.getProtectionDomain().getCodeSource().getLocation().getPath(). I reimplemented this code in a way that will work on all OSes.