### PR TITLE
Update Quality Rubric

### DIFF
--- a/chess/code-quality-rubric.md
+++ b/chess/code-quality-rubric.md
@@ -5,7 +5,7 @@ This document lists the criteria that the TAs will be using to grade your source
 
 | Category | Criteria | Weight |
 | :--- | :--- | ---: |
-| Naming | Method and variable names are clear and accurately represent their functionality/purpose<br/>Naming conventions and style are consistent (e.g., if you use snake case for local variables, always use snake case for local variables) | 25% |
+| Naming | Method and variable names are clear and accurately represent their functionality/purpose<br/>Naming conventions and style are consistent with [Java Naming Coventions](https://www.oracle.com/java/technologies/javase/codeconventions-namingconventions.html) | 25% |
 | Code Decomposition | Classes and methods obey the Single Responsibility Principle<br/>Classes and methods have been broken down so they are not overly long<br/>There are no large sections of duplicated code | 30% |
 | Readability | Code is easy to read<br/>Good and consistent use of whitespace<br/>Good use of comments, including avoiding unnecessary comments<br/>No dead code | 30% |
 | Package Structure | Code is effectively organized into well-named packages | 15% |


### PR DESCRIPTION
Updates the quality rubric to require java style naming conventions and links to [Oracle's naming conventions page](https://www.oracle.com/java/technologies/javase/codeconventions-namingconventions.html) if students are confused by that.

This is just an attempt to fix this, if you have a better idea of what to change that to, please use that instead of this.