### PR TITLE
Update all markdown links to instruction to a specific *.md page

### DIFF
--- a/chess/4-database/database.md
+++ b/chess/4-database/database.md
@@ -83,10 +83,10 @@ You will want to carefully consider the need for a Gson type adapter when you do
 ## Relevant Instruction Topics
 
 - [JSON and Serialization](../../instruction/json/json.md): Serialization objects to the database.
-- [Relational Databases](../../instruction/): How relational databases work.
+- [Relational Databases](../../instruction/db-model/db-model.md): How relational databases work.
 - [MYSQL](../../instruction/mysql/mysql.md): Getting MySQL installed.
-- [SQL](../../instruction/db-sql/): Using SQL statements.
-- [JDBC](../../instruction/db-jdbc/): Using SQL from Java including type adapters.
+- [SQL](../../instruction/db-sql/db-sql.md): Using SQL statements.
+- [JDBC](../../instruction/db-jdbc/db-jdbc.md): Using SQL from Java including type adapters.
 
 ## ☑ Deliverable
 


### PR DESCRIPTION
## The Problem
When I was reading the Phase 4 specs, I tried clicking the link to the instructional materials, but it took me to a directory instead. I noticed that several of the other links nearby had this same issue, but some of the links did directly point to the `.md` file.

In addition to fixing those three issues, I also searched for all other potential problems in the codebase. This commit fixes all

## Complete Solution
As part of this exercise, we searched all files with the following regex to ensure that we caught all instances of the problem. As it turns out, it turns out, there were no additional problem links besides the ones originally found.

This is the regex used to search for other potential issues.

```regex
(?<!!)\[.{1,40}?\]\((?!http|\w+-code).{1,50}?(?<!.md|.jpg|.java|starter-code|readme|.txt)\)
```

This started by searching for all markdown links, and then we excluded multiple kinds of acceptable links until we narrowed down the search results.

After fixing the errors contained in this commit, the only remaining result in the regex is a corner case to the location `.`. Because this, we can be sure that we've found all of the occurrences of this issue.

The only potentially questionable assumption we've made here is that links to code sometimes intend to reference the parent directory. That seems reasonable, but if that isn't always the intention, we can obviously fix it.