### PR TITLE
Add automatic scrolling for API test page

### DIFF
--- a/chess/3-web-api/starter-code/resources/web/index.html
+++ b/chess/3-web-api/starter-code/resources/web/index.html
@@ -97,7 +97,7 @@
         </td>
     </tr>
 </table>
-<h2>Execute</h2>
+<h2 id="execute">Execute</h2>
 <div class="box">
     <h3>Request</h3>
     <div class="input"><label for="method">Method:</label> <input type="text" id="method"/></div>

--- a/chess/3-web-api/starter-code/resources/web/index.js
+++ b/chess/3-web-api/starter-code/resources/web/index.js
@@ -41,6 +41,10 @@ function displayRequest(method, endpoint, request) {
   document.getElementById('handleBox').value = endpoint;
   const body = request ? JSON.stringify(request, null, 2) : '';
   document.getElementById('requestBox').value = body;
+  window.scrollBy({
+    top: document.getElementById('execute').getBoundingClientRect().top,
+    behavior:"smooth"
+  });
 }
 
 function clearAll() {


### PR DESCRIPTION
This adds automatic scrolling to the execution area when a endpoint button is clicked to the API test page. Many students are initially confused how to use the test page and I believe this would help them understand it more quickly and use it more efficiently.