### PR TITLE
Add auto-grader to repository assignment deliverable

### DIFF
--- a/chess/chess-github-repository/chess-github-repository.md
+++ b/chess/chess-github-repository/chess-github-repository.md
@@ -73,3 +73,5 @@ Submit the URL of your repository to the canvas assignment. The URL should look 
 ```txt
 https://github.com/<youraccount>/chess
 ```
+
+After submitting to Canvas, pass off with the course [auto-grading](https://cs240.click/) tool. If you created your repository correctly then your grade will automatically be entered in Canvas.


### PR DESCRIPTION
@Fiwafoofa Added the Chess GitHub Repository assignment into the auto-grader. It basically just checks to make sure the repository is cloneable/public and if they made a second commit (probably for notes.md). This adds a section to the deliverable section to the assignment specs telling them to submit to the auto-grader.

It's too late to require it for this semester (we've manually graded all of the submissions so far), but students should still be able to use it this semester if they haven't already done this assignment yet