### PR TITLE
update(chess-moves.md) Clarify validMoves requirements

### DIFF
--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -82,7 +82,7 @@ classDiagram
 This class serves as the top-level management of the chess game. It is responsible for executing moves as well as recording the game status.
 
 > [!IMPORTANT]
-> The ChessGame class is presented now, but will not be used until Phase 1.
+> Although the `ChessGame` class is presented now, it will not be used until Phase 1.\
 > ChessGame related tests will be [added to the working directory](../1-chess-game/getting-started.md#chess-game---getting-started) later.
 
 

--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -81,15 +81,10 @@ classDiagram
 
 This class serves as the top-level management of the chess game. It is responsible for executing moves as well as recording the game status.
 
-You will not need to implement any code in this class for this phase.
+> [!IMPORTANT]
+> The ChessGame class is presented now, but will not be used until Phase 1.
+> ChessGame related tests will be [added to the working directory](../1-chess-game/getting-started.md#chess-game---getting-started) later.
 
-#### Key Methods
-
-- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`.
-- **makeMove**: Receives a given move and executes it, provided it is a legal move. If the move is illegal, it throws an `InvalidMoveException`. A move is illegal if the chess piece cannot move there, if the move leaves the team’s king in danger, or if it’s not the corresponding team's turn.
-- **isInCheck**: Returns true if the specified team’s King could be captured by an opposing piece.
-- **isInCheckmate**: Returns true if the given team has no way to protect their king from being captured.
-- **isInStalemate**: Returns true if the given team has no legal moves and it is currently that team’s turn.
 
 ### ChessBoard
 
@@ -109,6 +104,8 @@ public enum PieceType {
     PAWN
 }
 ```
+
+`ChessPiece` implements rules that define how a piece moves independent of other chess rules such as check, stalement, or checkmate.
 
 #### Key Methods
 

--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -85,8 +85,8 @@ You will not need to implement any code in this class for this phase.
 
 #### Key Methods
 
-- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`. A move is valid if is a "piece move" for the piece at the input location _and_ making that move would not leave the team’s king in danger of check. 
-- **makeMove**: Receives a given move and executes it, provided it is a legal move. If the move is illegal, it throws an `InvalidMoveException`. A move is illegal if it is not a "valid" move for the piece at the starting location, _or_ if it’s not the corresponding team's turn.
+- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`.
+- **makeMove**: Receives a given move and executes it, provided it is a legal move. If the move is illegal, it throws an `InvalidMoveException`. A move is illegal if the chess piece cannot move there, if the move leaves the team’s king in danger, or if it’s not the corresponding team's turn.
 - **isInCheck**: Returns true if the specified team’s King could be captured by an opposing piece.
 - **isInCheckmate**: Returns true if the given team has no way to protect their king from being captured.
 - **isInStalemate**: Returns true if the given team has no legal moves and it is currently that team’s turn.

--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -85,8 +85,8 @@ You will not need to implement any code in this class for this phase.
 
 #### Key Methods
 
-- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`.
-- **makeMove**: Receives a given move and executes it, provided it is a legal move. If the move is illegal, it throws an `InvalidMoveException`. A move is illegal if the chess piece cannot move there, if the move leaves the team’s king in danger, or if it’s not the corresponding team's turn.
+- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`. A move is valid if is a "piece move" for the piece at the input location _and_ making that move would not leave the team’s king in danger of check. 
+- **makeMove**: Receives a given move and executes it, provided it is a legal move. If the move is illegal, it throws an `InvalidMoveException`. A move is illegal if it is not a "valid" move for the piece at the starting location, _or_ if it’s not the corresponding team's turn.
 - **isInCheck**: Returns true if the specified team’s King could be captured by an opposing piece.
 - **isInCheckmate**: Returns true if the given team has no way to protect their king from being captured.
 - **isInStalemate**: Returns true if the given team has no legal moves and it is currently that team’s turn.

--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -64,7 +64,9 @@ classDiagram
 
 This class serves as the top-level management of the Chess Game. It is responsible for executing moves as well as reporting the game status.
 
-`ChessGame` will now implement the rules of Chess not handled by the `ChessPiece` class. This will involve removing moves returned from `ChessPiece.validMoves()` that violate game rules.
+By default, a new `ChessGame` represents an immediately playable board with the pieces in their default locations and the starting player set to WHITE.
+
+`ChessGame` functionality will now implement the rules of Chess not handled by the `ChessPiece` class. This will involve removing moves returned from `ChessPiece.validMoves()` that violate game rules.
 
 **Key Methods**:
 

--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -66,8 +66,8 @@ This class serves as the top-level management of the Chess Game. It is responsib
 
 **Key Methods**:
 
-- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`.
-- **makeMove**: Receives a given move and executes it, provided it is a legal move. If the move is illegal, it throws an `InvalidMoveException`. A move is illegal if the chess piece cannot move there, if the move leaves the team’s king in danger, or if it’s not the corresponding team's turn.
+- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`. A move is valid if is a "piece move" for the piece at the input location _and_ making that move would not leave the team’s king in danger of check.
+- **makeMove**: Receives a given move and executes it, provided it is a legal move. If the move is illegal, it throws an `InvalidMoveException`. A move is illegal if it is not a "valid" move for the piece at the starting location, _or_ if it’s not the corresponding team's turn.
 - **isInCheck**: Returns true if the specified team’s King could be captured by an opposing piece.
 - **isInCheckmate**: Returns true if the given team has no way to protect their king from being captured.
 - **isInStalemate**: Returns true if the given team has no legal moves but their king is not in immediate danger.

--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -64,9 +64,11 @@ classDiagram
 
 This class serves as the top-level management of the Chess Game. It is responsible for executing moves as well as reporting the game status.
 
+`ChessGame` will now implement the rules of Chess not handled by the `ChessPiece` class. This will involve removing moves returned from `ChessPiece.validMoves()` that violate game rules.
+
 **Key Methods**:
 
-- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`. A move is valid if is a "piece move" for the piece at the input location _and_ making that move would not leave the team’s king in danger of check.
+- **validMoves**: Takes as input a position on the chessboard and returns all moves the piece there can legally make. If there is no piece at that location, this method returns `null`. A move is valid if it is a "piece move" for the piece at the input location _and_ making that move would not leave the team’s king in danger of check.
 - **makeMove**: Receives a given move and executes it, provided it is a legal move. If the move is illegal, it throws an `InvalidMoveException`. A move is illegal if it is not a "valid" move for the piece at the starting location, _or_ if it’s not the corresponding team's turn.
 - **isInCheck**: Returns true if the specified team’s King could be captured by an opposing piece.
 - **isInCheckmate**: Returns true if the given team has no way to protect their king from being captured.


### PR DESCRIPTION
Clarify requirements for `ChessGame.validMoves()` and `ChessGame.makeMove()` inside the Phase 1 specs. This provides students the details of which conditions should be verified in each method to represent the rules of chess.

Students have been able to figure this out by reasoning through the issue, but students less familiar with chess typically face a high burden here. Additionally, students are likely to misapply the verification of the current team's turn which— less intuitively— **should not** be verified in `ChessGame.validMoves()` because the `highlightMoves()` method needs to rely on it. However, this information isn't presented to students until much later in the project.

This change was peer reviewed by @Truthwatcher64 