### PR TITLE
Illuminate Issue of Changing SQL Tables

### DIFF
--- a/chess/4-database/database.md
+++ b/chess/4-database/database.md
@@ -42,6 +42,9 @@ As you design your database schema, carefully consider data types, primary and f
 > [!TIP]
 > The `DatabaseManager` class also has a method for creating a database if it does not exist. You are not required to use this code, but it is required that on start up, your code creates both your database and tables if they do not exist, based on the values configured in `db.properties`. This allows the pass off tests to run without manual intervention to set up your database.
 
+> [!TIP]
+> After your tables have created once, changing your `CREATE TABLE` statements will not actually affect the database. See [Changing Tables](../../instruction/db-sql/db-sql.md#changing-tables) for more information.
+
 The [Pet Shop](../../petshop/server/src/main/dataaccess/MySqlDataAccess.java) provides an example of how to initialize your database on start up if you are wondering how this is done.
 
 ## Password Hashing

--- a/instruction/db-sql/db-sql.md
+++ b/instruction/db-sql/db-sql.md
@@ -271,6 +271,13 @@ When we discuss the Java Database Connector (JDBC) we will demonstrate how to in
 
 You can also write a text file that contains SQL statements and execute them using the MySQL client shell (mysqlsh). For example, if you had an initialization SQL script that contained the following.
 
+> [!NOTE]
+> One of the key features of this script is the first line that `DROP`s the entire database, which includes all the tables and the data within them.
+>
+> This choice makes it easy to use in a development environment since changes the `CREATE TABLE` statements will be automatically applied; however, it comes with risks if the code were to be accidentally applied to a production database.
+>
+> You are free to use pattern for this project, but a mechanism for automatically dropping your existing tables **is not** included in the starter code in any way. You will likely need to devise your own mechanism for applying changes to tables.
+
 ```sql
 DROP DATABASE pet_store;
 CREATE DATABASE pet_store;

--- a/instruction/db-sql/db-sql.md
+++ b/instruction/db-sql/db-sql.md
@@ -65,7 +65,10 @@ All databases have a default character set that is used for representing bytes a
 ALTER DATABASE pet_store CHARACTER SET utf8mb4;
 ```
 
-If you want to delete a database, and all of the data it represents, you use the `DROP DATABASE` statement. Be careful with this statement. Once you run it there is no going back. The data is gone forever.
+If you want to delete a database, and all of the data it represents, you use the `DROP DATABASE` statement. While this should rarely be used in a production environment, it is common to drop databases in development environments so that changes to tables can be observed (see ["Changing Tables"](#changing-tables) for more info.)
+
+> [!CAUTION]
+> Be careful with this statement. Once you run it there is no going back. The data is gone forever.
 
 ```sql
 DROP DATABASE pet_store
@@ -88,19 +91,27 @@ Notice that each field is followed by the `NOT NULL` clause. That means each of 
 
 The `id` field is also annotated with the `AUTO_INCREMENT` keyword. This means that you don't actually provide the `id` field when you insert a row. The database will do that for you using an automatically increasing integer.
 
+### Changing Tables
+
+> [!IMPORTANT]
+> Simply changing a "Create Table" statement stored in the code **does not** change the database. Read on to understand valid ways to change a SQL table.
+
+A `CREATE TABLE` statement _only_ does the action implicit in its name. If the table already exists (a common scenario), this command will throw an error; its sister, `CREATE TABLE IF NOT EXISTS`, will suppress the error and perform a no-op operation on the database.
+
 If you need to alter your table you can use an `ALTER TABLE` statement. The following example shows you how to add a `nickname` field after the table is created. This alteration does not use the `NOT NULL` clause and so all of the existing nickname fields will be set to NULL. If a new row is added without specifying the nickname field, it will also be set to NULL.
 
 ```sql
 ALTER TABLE pet ADD COLUMN nickname VARCHAR(255);
 ```
 
-If you decide that you want to delete a table then you execute a `DROP TABLE` statement.
+If you decide that you want to delete a table then you execute a `DROP TABLE` statement. In a development environment where no meaningful data exists to lose, this kind of command is commonly used to allow changes in `CREATE TABLE` statements to take effect.
+
+> [!CAUTION]
+> Data loss alert! Make sure you really want to drop the table before you execute the command, because there is no recovery from this one.
 
 ```sql
 DROP TABLE pet;
 ```
-
-Make sure you really want to drop the table before you execute the command, because there is no recovery from this one.
 
 ### Primary Keys and Indexes
 

--- a/instruction/db-sql/db-sql.md
+++ b/instruction/db-sql/db-sql.md
@@ -86,7 +86,7 @@ CREATE TABLE pet (
 
 Notice that each field is followed by the `NOT NULL` clause. That means each of the fields must be provided for every row that is inserted.
 
-The `id` field is also annotated with the `AUTO_INCREMENT` keyword. This means that you don't actually provide the `id` field when you insert a row. The database will do that for you using an automatically increase integer.
+The `id` field is also annotated with the `AUTO_INCREMENT` keyword. This means that you don't actually provide the `id` field when you insert a row. The database will do that for you using an automatically increasing integer.
 
 If you need to alter your table you can use an `ALTER TABLE` statement. The following example shows you how to add a `nickname` field after the table is created. This alteration does not use the `NOT NULL` clause and so all of the existing nickname fields will be set to NULL. If a new row is added without specifying the nickname field, it will also be set to NULL.
 


### PR DESCRIPTION
## Motivation
A common theme in the TA help queue has been helping students understand that their changes to the `CREATE TABLE` statements are not actually affecting their database.

## Description
This PR adjusts language in the `db-sql.md` page to specifically address the topic of changing tables after they have been created, and installs a link to this on the Phase 4 project page.

I expect these adjustments to increase the overall awareness of the issue for students who read the materials, and also provide a mechanism by which a student reviewing the project page could have a hint about possible errors without having to talk to a TA.

## Potential Further Improvements
An instructional video on this detail could be a helpful supplemental resource, but isn't required for this PR.

Maintainers should feel free to adjust the language or wording of these adjustments.