### PR TITLE
Broaden "board orientation" requirement

### DIFF
--- a/chess/5-pregame/pregame.md
+++ b/chess/5-pregame/pregame.md
@@ -44,7 +44,7 @@ After the user has registered or logged in they can then execute any of the Post
 
 ### Gameplay UI
 
-As stated previously, gameplay will not be implemented until later. For now, when a user plays or observes a game, the client should draw the initial state of a Chess game in the terminal, but not actually enter gameplay mode. The chessboard should be drawn twice, once in each orientation (i.e., once with white pieces at the bottom and once with black pieces at the bottom).
+As stated previously, gameplay will not be implemented until later. For now, when a user plays or observes a game, the client should draw the initial state of a Chess game in the terminal, but not actually enter gameplay mode. When passing off, you must be able to demonstrate either orientation (i.e., with white pieces at the bottom or with black pieces at the bottom). The simplest way to do this for Phase 5 is to simply display both, as shown below.
 
 An example of what the chessboard might look like is given below. You are free to make your chessboard look different as long as the essential information is displayed in an easily readable way, but it must "look like a chess board." You must have different colors for alternating squares, but they don't have to be white and black. Light and dark, or white and brown, or whatever you'd like is fine. Per official chess rules, the bottom-right and top-left squares (h1 and a8) must be the "lighter" color. This will mean each queen is "on her color" (white queen on a light square, black queen on a dark square). In addition, you must show the correct row numbers and column letters, but can do so however you would like.
 


### PR DESCRIPTION
Now only requires the ability to demonstrate both orientations, rather than requiring them to both be printed together.