### PR TITLE
Demonstrate Error Stream Reading in PetShop Example with Test

### DIFF
--- a/petshop/server/src/main/server/PetServer.java
+++ b/petshop/server/src/main/server/PetServer.java
@@ -46,7 +46,7 @@ public class PetServer {
 
     private void exceptionHandler(ResponseException ex, Request req, Response res) {
         res.status(ex.StatusCode());
-        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse("Error: " + ex.getMessage());
         res.body(new Gson().toJson(errorResponse));
     }
 

--- a/petshop/server/src/main/server/PetServer.java
+++ b/petshop/server/src/main/server/PetServer.java
@@ -1,6 +1,7 @@
 package server;
 
 import com.google.gson.Gson;
+import exception.ErrorResponse;
 import exception.ResponseException;
 import model.Pet;
 import server.websocket.WebSocketHandler;
@@ -45,6 +46,8 @@ public class PetServer {
 
     private void exceptionHandler(ResponseException ex, Request req, Response res) {
         res.status(ex.StatusCode());
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        res.body(new Gson().toJson(errorResponse));
     }
 
     private Object addPet(Request req, Response res) throws ResponseException {

--- a/petshop/server/src/main/service/PetService.java
+++ b/petshop/server/src/main/service/PetService.java
@@ -21,7 +21,7 @@ public class PetService {
 
     public Pet addPet(Pet pet) throws ResponseException {
         if (pet.type() == PetType.DOG && pet.name().equals("fleas")) {
-            throw new ResponseException(200, "no dogs with fleas");
+            throw new ResponseException(418, "no dogs with fleas");
         }
         return dataAccess.addPet(pet);
     }

--- a/petshop/server/src/test/PetServerTest.java
+++ b/petshop/server/src/test/PetServerTest.java
@@ -1,10 +1,8 @@
 import dataaccess.MemoryDataAccess;
+import exception.ResponseException;
 import model.Pet;
 import model.PetType;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import server.PetServer;
 import server.ServerFacade;
 import service.PetService;
@@ -65,6 +63,19 @@ class PetServerTest {
 
         var result = assertDoesNotThrow(() -> server.listPets());
         assertPetCollectionEqual(expected, List.of(result));
+    }
+
+    @Test
+    void receiveErrorMessage() throws Exception {
+        // Dogs with fleas are not allowed
+        ResponseException error = Assertions.assertThrows(ResponseException.class,
+                () ->server.addPet(new Pet(-1, "fleas", PetType.DOG)),
+                "Inserting an invalid pet should throw an error");
+
+        Assertions.assertEquals(418, error.StatusCode(),
+                "Thrown exception should have the 418 status code specified by the server.");
+        Assertions.assertEquals("Error: no dogs with fleas", error.getMessage(),
+                "Thrown exception should contain the full, detailed error message");
     }
 
     public static void assertPetEqual(Pet expected, Pet actual) {

--- a/petshop/server/src/test/PetServerTest.java
+++ b/petshop/server/src/test/PetServerTest.java
@@ -69,7 +69,7 @@ class PetServerTest {
     void receiveErrorMessage() throws Exception {
         // Dogs with fleas are not allowed
         ResponseException error = Assertions.assertThrows(ResponseException.class,
-                () ->server.addPet(new Pet(-1, "fleas", PetType.DOG)),
+                () -> server.addPet(new Pet(-1, "fleas", PetType.DOG)),
                 "Inserting an invalid pet should throw an error");
 
         Assertions.assertEquals(418, error.StatusCode(),

--- a/petshop/shared/src/main/exception/ErrorResponse.java
+++ b/petshop/shared/src/main/exception/ErrorResponse.java
@@ -1,0 +1,4 @@
+package exception;
+
+public record ErrorResponse(String message) {
+}


### PR DESCRIPTION
Regarding Issue #157, it was recently discovered that Spark requires the error output to be read from a completely different stream (`getErrorStream()`).

Upon inspection of the PetShop example code, I discovered that the example does not even send the detailed error messages over the internet. This leads to frustrating experiences when students cannot see the actual error messages being sent. The example `PetServer` code was adjusted to send detailed error messages, and the `ServerFacade` is adapted to read and throw the error messages.

Tests are included that prove the error serialization and throwing work as expected. The test expects an error to be thrown when attempting to add a dog with fleas. This endpoint was originally returning a `200` status code (which is not an error); the status code was updated to [418 I'm A Teapot](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418) for the following reasons:
1. Represent an error status code
2. Avoid conflicts with other known status codes
3. Hopefully help someone laugh somewhere along the way