### PR TITLE
Remove indications that each feature is worth individual points...

### DIFF
--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -173,10 +173,10 @@ To pass off this assignment use the course [auto-grading](https://cs240.click/) 
 > You are required to commit to GitHub with every minor milestone. For example, after you successfully pass a test. This should result in a commit history that clearly details your work on this phase. If your Git history does not demonstrate your efforts then your submission may be rejected.
 
 | Category       | Criteria                                                                                          |       Points |
-| :------------- | :------------------------------------------------------------------------------------------------ | -----------: |
+|:---------------|:--------------------------------------------------------------------------------------------------|-------------:|
 | GitHub History | At least 8 GitHub commits evenly spread over the assignment period that demonstrate proof of work | Prerequisite |
 | Functionality  | All pass off test cases succeed                                                                   |          125 |
-|                | Total                                                                                             |          125 |
+|                | **Total**                                                                                         |      **125** |
 
 ## <a name="videos"></a>Videos (21:22)
 

--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -126,11 +126,11 @@ To pass off this assignment use the course [auto-grading](https://cs240.click/) 
 > You are required to commit to GitHub with every minor milestone. For example, after you successfully pass a test. This should result in a commit history that clearly details your work on this phase. If your Git history does not demonstrate your efforts then your submission may be rejected.
 
 | Category       | Criteria                                                                                          |       Points |
-| :------------- | :------------------------------------------------------------------------------------------------ | -----------: |
+|:---------------|:--------------------------------------------------------------------------------------------------|-------------:|
 | GitHub History | At least 8 GitHub commits evenly spread over the assignment period that demonstrate proof of work | Prerequisite |
 | Functionality  | All pass off test cases succeed                                                                   |          125 |
 | Extra Credit   | `extracredit` test cases succeed                                                                  |    bonus +10 |
-|                | Total                                                                                             |          125 |
+|                | **Total**                                                                                         |      **125** |
 
 ## <a name="videos"></a>Videos (6:13)
 

--- a/chess/3-web-api/web-api.md
+++ b/chess/3-web-api/web-api.md
@@ -440,12 +440,12 @@ After your code has successfully been auto-graded, a TA will review the code in 
 > You are required to commit to GitHub with every minor milestone. For example, after you successfully pass a test. This should result in a commit history that clearly details your work on this phase. If your Git history does not demonstrate your efforts then your submission may be rejected.
 
 | Category       | Criteria                                                                                                                                                                                         |       Points |
-| :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----------: |
+|:---------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------:|
 | GitHub History | At least 12 GitHub commits evenly spread over the assignment period that demonstrate proof of work                                                                                               | Prerequisite |
 | Web API Works  | All pass off test cases succeed                                                                                                                                                                  |          125 |
 | Code Quality   | [Rubric](../code-quality-rubric.md)                                                                                                                                                              |           30 |
 | Unit Tests     | All test cases pass<br/>Each public method on your **Service classes** has two test cases, one positive test and one negative test<br/>Every test case includes an Assert statement of some type |           25 |
-|                | Total                                                                                                                                                                                            |          180 |
+|                | **Total**                                                                                                                                                                                        |      **180** |
 
 ## <a name="videos"></a>Videos (38:14)
 

--- a/chess/4-database/database.md
+++ b/chess/4-database/database.md
@@ -133,12 +133,12 @@ If your tests are passing locally but not on the autograder, here are some thing
 > You are required to commit to GitHub with every minor milestone. For example, after you successfully pass a test. This should result in a commit history that clearly details your work on this phase. If your Git history does not demonstrate your efforts then your submission may be rejected.
 
 | Category       | Criteria                                                                                                                                                                            |       Points |
-| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----------: |
+|:---------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------:|
 | GitHub History | At least 12 GitHub commits evenly spread over the assignment period that demonstrate proof of work                                                                                  | Prerequisite |
 | Functionality  | All pass off test cases succeed                                                                                                                                                     |          100 |
 | Code Quality   | [Rubric](../code-quality-rubric.md)                                                                                                                                                 |           30 |
 | Unit Tests     | All test cases pass<br/>Each public method on DAO classes has two test cases, one positive test and one negative test<br/>Every test case includes an Assert statement of some type |           25 |
-|                | Total                                                                                                                                                                               |          155 |
+|                | **Total**                                                                                                                                                                           |      **155** |
 
 ## <a name="videos"></a>Videos (29:30)
 

--- a/chess/5-pregame/pregame.md
+++ b/chess/5-pregame/pregame.md
@@ -158,12 +158,12 @@ To pass off this assignment submit your work to the course [auto-grading](https:
 > You are required to commit to GitHub with every minor milestone. For example, after you successfully pass a test. This should result in a commit history that clearly details your work on this phase. If your Git history does not demonstrate your efforts then your submission may be rejected.
 
 | Category       | Criteria                                                                                                                                                                                        |       Points |
-| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----------: |
+|:---------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------:|
 | GitHub History | At least 12 GitHub commits evenly spread over the assignment period that demonstrate proof of work                                                                                              | Prerequisite |
 | Functionality  | Program supports all required functionality                                                                                                                                                     |          100 |
 | Code Quality   | [Rubric](../code-quality-rubric.md)                                                                                                                                                             |           30 |
 | Unit Tests     | All test cases pass<br/>Each public method on the Server Facade class has two test cases, one positive test and one negative test<br/>Every test case includes an Assert statement of some type |           25 |
-|                | Total                                                                                                                                                                                           |          155 |
+|                | **Total**                                                                                                                                                                                       |      **155** |
 
 ## <a name="videos"></a>Videos (38:10)
 

--- a/chess/6-gameplay/gameplay.md
+++ b/chess/6-gameplay/gameplay.md
@@ -219,23 +219,23 @@ To pass off this assignment submit your work to the course [auto-grading](https:
 
 ### Grading Rubric
 
-| Category                      | Criteria                                                                                                                                      |       Points |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -----------: |
-| GitHub History                | At least 12 GitHub commits evenly spread over the assignment period that demonstrate proof of work.                                           | Prerequisite |
-| Automated Pass Off Test Cases | Each provided test case passed is worth a proportional number of points ((passed / total) \* 50).                                             |           50 |
-| Program Functionality         | All-or-nothing rubric item. Complete all of the following behaviors:                                                                          |           75 |
-| Feat: **Help Text**           | Useful help text is displayed informing the user what actions they can take.                                                                  |            - |
-| Feat: **Observer Connect**    | Observers can connect to a game. Notification sent and board drawn.                                                                           |            - |
-| Feat: **Observer Leave Game** | Observers can leave games. Notification sent.                                                                                                 |            - |
-| Feat: **Player Connect**      | Players can connect to a game as a specified color. Notification sent and board drawn.                                                        |            - |
-| Feat: **Player Move Piece**   | Players can move pieces. Illegal moves rejected. Notification sent (including check or checkmate notification if applicable) and board drawn. |            - |
-| Feat: **Player Leave Game**   | Players can leave games. Notification sent.                                                                                                   |            - |
-| Feat: **Player Resign Game**  | Players can resign from games. Notification sent.                                                                                             |            - |
-| Feat: **Display Legal Moves** | Any player or observer can display the legal moves available to any piece on the board regardless of whose turn it is.                        |            - |
-| Feat: **Redraw Board**        | The board redraws when requested by the user (player or observer).                                                                            |            - |
-| Feat: **Game completion**     | No moves after game completion due to resignation, checkmate, or stalemate.                                                                   |            - |
-| Code Quality                  | [Rubric](../code-quality-rubric.md)                                                                                                           |           30 |
-|                               | Total                                                                                                                                         |          155 |
+| Category                      | Criteria                                                                                                                                                             |       Points |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----------: |
+| GitHub History                | At least 12 GitHub commits evenly spread over the assignment period that demonstrate proof of work.                                                                  | Prerequisite |
+| Automated Pass Off Test Cases | Each provided test case passed is worth a proportional number of points ((passed / total) \* 50).                                                                    |           50 |
+| Program Functionality         | All-or-nothing rubric item. Complete all of the following behaviors:                                                                                                 |           75 |
+|                               | **Help Text**: Useful help text is displayed informing the user what actions they can take.                                                                          |              |
+|                               | **Observer Connect**: Observers can connect to a game. Notification sent and board drawn.                                                                            |              |
+|                               | **Observer Leave Game**: Observers can leave games. Notification sent.                                                                                               |              |
+|                               | **Player Connect**: Players can connect to a game as a specified color. Notification sent and board drawn.                                                           |              |
+|                               | **Player Move Piece**: Players can move pieces. Illegal moves rejected. Notification sent (including check or checkmate notification if applicable) and board drawn. |              |
+|                               | **Player Leave Game**: Players can leave games. Notification sent.                                                                                                   |              |
+|                               | **Player Resign Game**: Players can resign from games. Notification sent.                                                                                            |              |
+|                               | **Display Legal Moves**: Any player or observer can display the legal moves available to any piece on the board regardless of whose turn it is.                      |              |
+|                               | **Redraw Board**: The board redraws when requested by the user (player or observer).                                                                                 |              |
+|                               | **Game completion**: No moves after game completion due to resignation, checkmate, or stalemate.                                                                     |              |
+| Code Quality                  | [Rubric](../code-quality-rubric.md)                                                                                                                                  |           30 |
+|                               | Total                                                                                                                                                                |          155 |
 
 ## <a name="videos"></a>Videos (10:39)
 

--- a/chess/6-gameplay/gameplay.md
+++ b/chess/6-gameplay/gameplay.md
@@ -223,16 +223,17 @@ To pass off this assignment submit your work to the course [auto-grading](https:
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -----------: |
 | GitHub History                | At least 12 GitHub commits evenly spread over the assignment period that demonstrate proof of work.                                           | Prerequisite |
 | Automated Pass Off Test Cases | Each provided test case passed is worth a proportional number of points ((passed / total) \* 50).                                             |           50 |
-| Help Text                     | Useful help text is displayed informing the user what actions they can take.                                                                  |            5 |
-| Observer Connect              | Observers can connect to a game. Notification sent and board drawn.                                                                           |            5 |
-| Observer Leave Game           | Observers can leave games. Notification sent.                                                                                                 |            5 |
-| Player Connect                | Players can connect to a game as a specified color. Notification sent and board drawn.                                                        |            5 |
-| Player Move Piece             | Players can move pieces. Illegal moves rejected. Notification sent (including check or checkmate notification if applicable) and board drawn. |           15 |
-| Player Leave Game             | Players can leave games. Notification sent.                                                                                                   |            5 |
-| Player Resign Game            | Players can resign from games. Notification sent.                                                                                             |            5 |
-| Display Legal Moves           | Any player or observer can display the legal moves available to any piece on the board regardless of whose turn it is.                        |           10 |
-| Redraw Board                  | The board redraws when requested by the user (player or observer).                                                                            |            5 |
-| Game completion               | No moves after game completion due to resignation, checkmate, or stalemate.                                                                   |           15 |
+| Program Functionality         | All-or-nothing rubric item. Complete all of the following behaviors:                                                                          |           75 |
+| Feat: **Help Text**           | Useful help text is displayed informing the user what actions they can take.                                                                  |            - |
+| Feat: **Observer Connect**    | Observers can connect to a game. Notification sent and board drawn.                                                                           |            - |
+| Feat: **Observer Leave Game** | Observers can leave games. Notification sent.                                                                                                 |            - |
+| Feat: **Player Connect**      | Players can connect to a game as a specified color. Notification sent and board drawn.                                                        |            - |
+| Feat: **Player Move Piece**   | Players can move pieces. Illegal moves rejected. Notification sent (including check or checkmate notification if applicable) and board drawn. |            - |
+| Feat: **Player Leave Game**   | Players can leave games. Notification sent.                                                                                                   |            - |
+| Feat: **Player Resign Game**  | Players can resign from games. Notification sent.                                                                                             |            - |
+| Feat: **Display Legal Moves** | Any player or observer can display the legal moves available to any piece on the board regardless of whose turn it is.                        |            - |
+| Feat: **Redraw Board**        | The board redraws when requested by the user (player or observer).                                                                            |            - |
+| Feat: **Game completion**     | No moves after game completion due to resignation, checkmate, or stalemate.                                                                   |            - |
 | Code Quality                  | [Rubric](../code-quality-rubric.md)                                                                                                           |           30 |
 |                               | Total                                                                                                                                         |          155 |
 

--- a/chess/6-gameplay/gameplay.md
+++ b/chess/6-gameplay/gameplay.md
@@ -220,7 +220,7 @@ To pass off this assignment submit your work to the course [auto-grading](https:
 ### Grading Rubric
 
 | Category                      | Criteria                                                                                                                                                             |       Points |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----------: |
+|:------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------:|
 | GitHub History                | At least 12 GitHub commits evenly spread over the assignment period that demonstrate proof of work.                                                                  | Prerequisite |
 | Automated Pass Off Test Cases | Each provided test case passed is worth a proportional number of points ((passed / total) \* 50).                                                                    |           50 |
 | Program Functionality         | All-or-nothing rubric item. Complete all of the following behaviors:                                                                                                 |           75 |
@@ -235,7 +235,7 @@ To pass off this assignment submit your work to the course [auto-grading](https:
 |                               | **Redraw Board**: The board redraws when requested by the user (player or observer).                                                                                 |              |
 |                               | **Game completion**: No moves after game completion due to resignation, checkmate, or stalemate.                                                                     |              |
 | Code Quality                  | [Rubric](../code-quality-rubric.md)                                                                                                                                  |           30 |
-|                               | Total                                                                                                                                                                |          155 |
+|                               | **Total**                                                                                                                                                            |      **155** |
 
 ## <a name="videos"></a>Videos (10:39)
 


### PR DESCRIPTION
Resolves #170.

## Implementation Details

Originally, I attempted to solve this by listing all of the features in a bulleted list in a single row of the table. This most accurately reflects the grading realities; however, it is very difficult to maintain since markdown files do not have builtin support for lists within tables. The workaround requires using HTML tags (which is fine), but then they all have to be condensed into a single line for the markdown to render properly.

In this approach, we remove the points from each item and indicate that they are sub-topics of the parent item which is 'Program Functionality'. I chose the abbreviation 'feat:' because it is short and conveys the intention of the full word 'functionality.'

I considered using ASCII characters to create a directory-like structure, but I figured that wouldn't actually work well from separate table rows.