### PR TITLE
Use HttpClient instead of HttpURLConnection

### DIFF
--- a/instruction/web-api/example-code/client-web-api/GetExample.java
+++ b/instruction/web-api/example-code/client-web-api/GetExample.java
@@ -1,39 +1,40 @@
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
 
 public class GetExample {
+    private static final HttpClient client = HttpClient.newHttpClient();
 
-    public void doGet(String urlString) throws IOException {
-        URL url = new URL(urlString);
+    public static void main(String[] args) throws IOException, InterruptedException {
+        var example = doGet("https://example.com/");
+        System.out.println(example);
+    }
 
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    public static String doGet(String urlString) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder(URI.create(urlString))
+                .GET()
+                .timeout(Duration.ofSeconds(5))
+                // Set HTTP request headers, if necessary
+                // .header("Accept", "text/html")
+                // .header("Authorization", "fjaklc8sdfjklakl")
+                .build();
 
-        connection.setReadTimeout(5000);
-        connection.setRequestMethod("GET");
-
-        // Set HTTP request headers, if necessary
-        // connection.addRequestProperty("Accept", "text/html");
-        // connection.addRequestProperty("Authorization", "fjaklc8sdfjklakl");
-
-        connection.connect();
-
-        if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
-            // Get HTTP response headers, if necessary
-            // Map<String, List<String>> headers = connection.getHeaderFields();
-
-            // OR
-
-            //connection.getHeaderField("Content-Length");
-
-            InputStream responseBody = connection.getInputStream();
-            // Read and process response body from InputStream ...
-        } else {
-            // SERVER RETURNED AN HTTP ERROR
-
-            InputStream responseBody = connection.getErrorStream();
-            // Read and process error response body from InputStream ...
+        var response = client.send(request, BodyHandlers.ofString());
+        var successful = response.statusCode() == 200;
+        if (!successful) {
+            return null;
         }
+
+        // Get response headers, if necessary
+        // HttpHeaders headers = response.headers();
+        // Optional<String> contentLength = headers.firstValue("Content-Length")
+
+        // String because we used BodyHandlers.ofString()
+        // Can be a different type with a different BodyHandler
+        String body = response.body();
+        return body;
     }
 }

--- a/instruction/web-api/example-code/client-web-api/PostExample.java
+++ b/instruction/web-api/example-code/client-web-api/PostExample.java
@@ -1,45 +1,34 @@
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
 
 public class PostExample {
+    private static final HttpClient client = HttpClient.newHttpClient();
 
-    public void doPost(String urlString) throws IOException {
-        URL url = new URL(urlString);
+    public String doPost(String urlString, String body) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder(URI.create(urlString))
+                // Use a different BodyPublisher for other types of input
+                .POST(BodyPublishers.ofString(body))
+                .timeout(Duration.ofSeconds(5))
+                .build();
 
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-
-        connection.setReadTimeout(5000);
-        connection.setRequestMethod("POST");
-        connection.setDoOutput(true);
-
-        // Set HTTP request headers, if necessary
-        // connection.addRequestProperty("Accept", "text/html");
-
-        connection.connect();
-
-        try(OutputStream requestBody = connection.getOutputStream();) {
-            // Write request body to OutputStream ...
+        var response = client.send(request, BodyHandlers.ofString());
+        var successful = response.statusCode() == 200;
+        if (!successful) {
+            return null;
         }
 
-        if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
-            // Get HTTP response headers, if necessary
-            // Map<String, List<String>> headers = connection.getHeaderFields();
+        // Get response headers, if necessary
+        // HttpHeaders headers = response.headers();
+        // Optional<String> contentLength = headers.firstValue("Content-Length")
 
-            // OR
-
-            //connection.getHeaderField("Content-Length");
-
-            InputStream responseBody = connection.getInputStream();
-            // Read response body from InputStream ...
-        }
-        else {
-            // SERVER RETURNED AN HTTP ERROR
-
-            InputStream responseBody = connection.getErrorStream();
-            // Read and process error response body from InputStream ...
-        }
+        // String because we used BodyHandlers.ofString()
+        // Can be a different type with a different BodyHandler
+        String responseBody = response.body();
+        return responseBody;
     }
 }

--- a/instruction/web-api/web-api.md
+++ b/instruction/web-api/web-api.md
@@ -413,6 +413,7 @@ java -cp ../../lib/gson-2.10.1.jar ClientCurlExample.java POST 'http://localhost
 - 🎥 [Spark Installation (2:11)](https://byu.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=aa878216-922c-43ca-ae25-b18c0159089a) - [[transcript]](https://github.com/user-attachments/files/17753801/CS_240_Installation_Transcript.pdf)
 - 🎥 [Pet Shop Demo (9:43)](https://byu.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=751fc126-9541-485a-b712-b18c0159fe8c) - [[transcript]](https://github.com/user-attachments/files/17753811/CS_240_Petshop_Demo_Transcript.pdf)
 - 🎥 [Client HTTP (12:11) [OUTDATED]](https://byu.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=781ae49b-6284-4e1a-836b-b1930162c54b) - [[transcript]](https://github.com/user-attachments/files/17753820/CS_240_Client_HTTP_Transcript.pdf)
+  - NOTE: This video uses the older `HttpURLConnection` rather than `HttpClient`. We recommend using `HttpClient` as it provides a simpler, more streamlined API.
 
 ## Demonstration code
 

--- a/petshop/shared/src/main/server/ServerFacade.java
+++ b/petshop/shared/src/main/server/ServerFacade.java
@@ -5,17 +5,19 @@ import exception.ErrorResponse;
 import exception.ResponseException;
 import model.Pet;
 
-import java.io.*;
 import java.net.*;
+import java.net.http.*;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
 
 public class ServerFacade {
-
+    private final HttpClient client = HttpClient.newHttpClient();
     private final String serverUrl;
 
     public ServerFacade(String url) {
         serverUrl = url;
     }
-
 
     public Pet addPet(Pet pet) throws ResponseException {
         var path = "/pet";
@@ -40,17 +42,12 @@ public class ServerFacade {
         return response.pet();
     }
 
-    private <T> T makeRequest(String method, String path, Object request, Class<T> responseClass) throws ResponseException {
+    private <T> T makeRequest(String method, String path, Object body, Class<T> responseClass)
+            throws ResponseException {
         try {
-            URL url = (new URI(serverUrl + path)).toURL();
-            HttpURLConnection http = (HttpURLConnection) url.openConnection();
-            http.setRequestMethod(method);
-            http.setDoOutput(true);
-
-            writeBody(request, http);
-            http.connect();
-            throwIfNotSuccessful(http);
-            return readBody(http, responseClass);
+            var request = buildRequest(method, path, body);
+            var response = client.send(request, BodyHandlers.ofString());
+            return handleResponse(response, responseClass);
         } catch (ResponseException ex) {
             throw ex;
         } catch (Exception ex) {
@@ -58,43 +55,41 @@ public class ServerFacade {
         }
     }
 
+    private HttpRequest buildRequest(String method, String path, Object body) {
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(serverUrl + path))
+                .method(method, makeRequestBody(body));
+        if (body != null) {
+            request.setHeader("Content-Type", "application/json");
+        }
+        return request.build();
+    }
 
-    private static void writeBody(Object request, HttpURLConnection http) throws IOException {
+    private BodyPublisher makeRequestBody(Object request) {
         if (request != null) {
-            http.addRequestProperty("Content-Type", "application/json");
-            String reqData = new Gson().toJson(request);
-            try (OutputStream reqBody = http.getOutputStream()) {
-                reqBody.write(reqData.getBytes());
-            }
+            return BodyPublishers.ofString(new Gson().toJson(request));
+        } else {
+            return BodyPublishers.noBody();
         }
     }
 
-    private void throwIfNotSuccessful(HttpURLConnection http) throws IOException, ResponseException {
-        var status = http.getResponseCode();
+    private <T> T handleResponse(HttpResponse<String> response, Class<T> responseClass) throws ResponseException {
+        var status = response.statusCode();
         if (!isSuccessful(status)) {
-            try (InputStream respErr = http.getErrorStream()) {
-                if (respErr != null) {
-                    throw ResponseException.fromJson(respErr);
-                }
+            var body = response.body();
+            if (body != null) {
+                throw new Gson().fromJson(response.body(), ResponseException.class);
             }
 
             throw new ResponseException(status, "other failure: " + status);
         }
-    }
 
-    private static <T> T readBody(HttpURLConnection http, Class<T> responseClass) throws IOException {
-        T response = null;
-        if (http.getContentLength() < 0) {
-            try (InputStream respBody = http.getInputStream()) {
-                InputStreamReader reader = new InputStreamReader(respBody);
-                if (responseClass != null) {
-                    response = new Gson().fromJson(reader, responseClass);
-                }
-            }
+        if (responseClass == null) {
+            return null;
         }
-        return response;
-    }
 
+        return new Gson().fromJson(response.body(), responseClass);
+    }
 
     private boolean isSuccessful(int status) {
         return status / 100 == 2;


### PR DESCRIPTION
This PR changes the HTTP clients in this repository to use `HttpClient` instead of `HttpURLConnection`, per #169.

Specifically, it changes [GetExample.java](https://github.com/21aslade/cs240/tree/http-client/instruction/web-api/example-code/client-web-api/GetExample.java), [PostExample.java](https://github.com/21aslade/cs240/tree/http-client/instruction/web-api/example-code/client-web-api/PostExample.java), and the examples in [web-api.md](https://github.com/21aslade/cs240/tree/http-client/instruction/web-api/web-api.md). [example-code/old](https://github.com/21aslade/cs240/tree/http-client/instruction/web-api/example-code/old) is unchanged, as it isn't linked anywhere and doesn't seem to be maintained.

Note that because `HttpResponse` doesn't support an equivalent to `HttpURLConnection::getResponseMessage` for some reason, that functionality is removed from the curl clone :frowning: I don't think that's worth the cost of continuing to use `HttpURLConnection`, though, as `HttpClient` makes the code much simpler.

Fixes #169 