### PR TITLE
correct spelling of stalemate

### DIFF
--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -106,7 +106,7 @@ public enum PieceType {
 }
 ```
 
-`ChessPiece` implements rules that define how a piece moves independent of other chess rules such as check, stalement, or checkmate.
+`ChessPiece` implements rules that define how a piece moves independent of other chess rules such as check, stalemate, or checkmate.
 
 #### Key Methods
 


### PR DESCRIPTION
Was 'stalement', now 'stalemate'