### PR TITLE
Update chess-github-repository.md : Use only default branch of template

### DIFF
--- a/chess/chess-github-repository/chess-github-repository.md
+++ b/chess/chess-github-repository/chess-github-repository.md
@@ -41,6 +41,7 @@ If you do not have the required number of commits, or if they are all clustered 
    1. Optionally, give it a meaningful description such as:
        > Full-stack chess application built as a course project for BYU CS 240. It features a networked client-server architecture, with a command-line client, a server to manage users and games, and shared modules for implementing chess rules and game state management.
    1. Mark the repository as `public` so that it can be reviewed by the TAs and instructors. (This is the default.)
+   1. Leave the box marked `Include all branches` unchecked. (This is the default.)
    1. Press "Create Repository"
 
       ![create repo](create-repo.png)


### PR DESCRIPTION
Earlier today, a student was confused about why there were multiple branches in their repository, which was because they checked the box to include all the branches when creating their repository from the template. This would add an instruction to leave the box for that unchecked.