### PR TITLE
Updating chess-moves.md to include links.

### DIFF
--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -128,6 +128,8 @@ In most cases, the default methods provided by IntelliJ will suffice. However, t
 
 The tests and autograder rely on these methods in order to compare your objects. If you can't pass any tests even though the output seems the same check to make sure that these methods are created and working properly.
 
+To understand why we need to override the `equals()` and `hashCode()` methods see the following documentation on [Java Object Class](https://github.com/softwareconstruction240/softwareconstruction/blob/main/instruction/java-object-class/java-object-class.md)
+
 > [!TIP]
 > Debugging is often much easier if you also override the `toString()` method and return a concise representation of the object. This is not required, but highly recommended. This can be generated in the same way that the `equals()` and `hashcode()` were.
 


### PR DESCRIPTION
As suggested during the TA meeting, we thought it would be helpful to include the link to documentation explaining why we actually need to override equals and hashCode functions.