### PR TITLE
Update chess-game.md Adjust formatting...

### DIFF
--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -122,7 +122,7 @@ This represents a location on the chessboard. This should be represented as a ro
 
 ## Object Overrides
 
-In order for the tests to pass, you are required to override the `equals()` and `hashCode()` methods in your class implementations as necessary. This includes the ChessPosition, ChessPiece, ChessMove, and ChessBoard classes in particular. To do this automatically in IntelliJ, right click on the class code and select `Code > Generate... > equals() and hashCode()`. It is a good idea to generate these methods fairly early. However, IntelliJ will not be able to generate them properly until you have added the required fields to the class.
+In order for the tests to pass, you are required to override the `equals()` and `hashCode()` methods in your class implementations as necessary. This includes the `ChessPosition`, `ChessPiece`, `ChessMove`, and `ChessBoard` classes in particular. To do this automatically in IntelliJ, right click on the class code and select `Code > Generate... > equals() and hashCode()`. It is a good idea to generate these methods fairly early. However, IntelliJ will not be able to generate them properly until you have added the required fields to the class.
 
 In most cases, the default methods provided by IntelliJ will suffice. However, there are cases when the generated code will not completely work. You should fully understand all code in your project. Even code that was generated for you. Take the time to carefully review and debug what the generated code does. Add a breakpoint, inspect the variables, and step through each line.
 

--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -124,7 +124,7 @@ This represents a location on the chessboard. This should be represented as a ro
 
 In order for the tests to pass, you are required to override the `equals()` and `hashCode()` methods in your class implementations as necessary. This includes the `ChessPosition`, `ChessPiece`, `ChessMove`, and `ChessBoard` classes in particular. To do this automatically in IntelliJ, right click on the class code and select `Code > Generate... > equals() and hashCode()`. It is a good idea to generate these methods fairly early. However, IntelliJ will not be able to generate them properly until you have added the required fields to the class.
 
-In most cases, the default methods provided by IntelliJ will suffice. However, there are cases when the generated code will not completely work. You should fully understand all code in your project. Even code that was generated for you. Take the time to carefully review and debug what the generated code does. Add a breakpoint, inspect the variables, and step through each line.
+In most cases, the default methods provided by IntelliJ will suffice. However, there are cases when the generated code will not completely work. You should fully understand all code in your project, even code that was generated for you. Take the time to carefully review and debug what the generated code does. Add a breakpoint, inspect the variables, and step through each line.
 
 The tests and autograder rely on these methods in order to compare your objects. If you can't pass any tests even though the output seems the same check to make sure that these methods are created and working properly.
 

--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -79,11 +79,11 @@ By default, a new `ChessGame` represents an immediately playable board with the 
 
 ## Extra Credit Moves
 
-If you would like to fully implement the rules of chess you need to provide support for `En Passant` and `Castling`.
+If you would like to fully implement the rules of chess you need to provide support for "En Passant" and "Castling".
 
 You do not have to implement these moves, but if you go the extra mile and successfully implement them, you’ll earn 5 extra credit points for each move (10 total) on this assignment.
 
-**`Castling`**
+### Castling
 
 This is a special move where the King and a Rook move simultaneously. The castling move can only be taken when 3 conditions are met:
 
@@ -91,11 +91,11 @@ This is a special move where the King and a Rook move simultaneously. The castli
 2. There are no pieces between the King and the Rook
 3. **The King is never in Check.** The King does not start in Check, does not cross a square on which it would be in Check, and is not in Check after castling.
 
-To Castle, the King moves 2 spaces towards the Rook, and the Rook "jumps" the king moving to the position next to and on the other side of the King. This is represented in a ChessMove as the king moving 2 spaces to the side.
+To Castle, the King moves 2 spaces towards the Rook, and the Rook "jumps" the king moving to the position next to and on the other side of the King. This is represented in a `ChessMove` as the king moving 2 spaces to the side.
 
-**`En Passant`**
+### En Passant
 
-This is a special move taken by a Pawn in response to your opponent double moving a Pawn. If your opponent double moves a pawn so it ends next to yours (skipping the position where your pawn could have captured their pawn), then on your immediately following turn your pawn may capture their pawn as if their pawn had only moved 1 square. This is as if your pawn is capturing their pawn mid motion, or `In Passing`.
+This is a special move taken by a Pawn in response to your opponent double moving a Pawn. If your opponent double moves a pawn so it ends next to yours (skipping the position where your pawn could have captured their pawn), then on your immediately following turn your pawn may capture their pawn as if their pawn had only moved 1 square. This is as if your pawn is capturing their pawn mid motion, or "In Passing."
 
 ## Code Quality
 

--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -79,7 +79,7 @@ By default, a new `ChessGame` represents an immediately playable board with the 
 
 ## Extra Credit Moves
 
-If you would like to fully implement the rules of chess you need to provide support for "En Passant" and "Castling".
+If you would like to fully implement the rules of chess you need to provide support for **Castling** and **En Passant**.
 
 You do not have to implement these moves, but if you go the extra mile and successfully implement them, you’ll earn 5 extra credit points for each move (10 total) on this assignment.
 


### PR DESCRIPTION
- Use proper sub-headings rather than mere bold. This allows for directly linking to a subsection.
- Remove inappropriate use of backtics for non-code. Emphasize the terms Castling and En Passant by their location in the sub-headings.
- Add backtics around `ChessMove` code reference.