### PR TITLE
Rewrite ChessPiece.validMoves description...

### DIFF
--- a/chess/0-chess-moves/chess-moves.md
+++ b/chess/0-chess-moves/chess-moves.md
@@ -110,7 +110,7 @@ public enum PieceType {
 
 #### Key Methods
 
-- **pieceMoves**: This method is similar to `ChessGame.validMoves`, except it does not honor whose turn it is or check if the king is being attacked. This method does account for enemy and friendly pieces blocking movement paths. The `pieceMoves` method will need to take into account the type of piece, and the location of other pieces on the board.
+- **`pieceMoves`**: Called on a particular piece and being provided its position and the board as context, this method returns all moves the piece can legally make. `ChessPiece.validMoves` accounts for the type of piece and the locations of enemy and friendly pieces blocking movement paths. As the precursor to `ChessGame.validMoves`, this method provides most of the behavior of the chess moves, except it does not honor whose turn it is or check if the king is being attacked.
 
 ### ChessMove
 


### PR DESCRIPTION
- Include the line 'returns all the moves the piece can legally make'
    - This is a very helpful line in understanding the behavior of the method, especially in connection with the pawn promotion moves.
    - The line used to be included in Phase 0, but was removed when we eliminated the `ChessGame` content to avoid confusion.
- Discuss the information and context available to the method
- Rewrite it's relationship to the future ChessGame.validMoves
- Emphasize the role it does play, rather than the things it doesn't do