### PR TITLE
Fix Phase 5 spec spacing to fix tip alert

### DIFF
--- a/chess/5-pregame/pregame.md
+++ b/chess/5-pregame/pregame.md
@@ -93,7 +93,8 @@ Write positive and negative unit tests for each method on your ServerFacade clas
 
 Your tests must be located in the file `client/src/test/java/client/ServerFacadeTests.java`, provided in the starter code.
 
-> [!TIP] > `ServerFacadeTests.java` contains code that will automatically start and shutdown your server on a randomly assigned port as part of the test. However, you will still need to start your server using the `Main.main` function when you manually run your client.
+> [!TIP] 
+> `ServerFacadeTests.java` contains code that will automatically start and shutdown your server on a randomly assigned port as part of the test. However, you will still need to start your server using the `Main.main` function when you manually run your client.
 
 ```java
 public class ServerFacadeTests {


### PR DESCRIPTION
Due to a missing newline in the Markdown file for the Phase 5 spec, the tip to start the server looked like this: 

> [!TIP] > `ServerFacadeTests.java` contains code that will automatically start and shutdown your server on a randomly assigned port as part of the test. However, you will still need to start your server using the `Main.main` function when you manually run your client.

It's possible students missed this tip, as some probably aren't very literate in markdown syntax, and this mistake displays the text grayed out. This fix adds the newline so that the colorful tip alert is displayed correctly.

> [!TIP] 
> `ServerFacadeTests.java` contains code that will automatically start and shutdown your server on a randomly assigned port as part of the test. However, you will still need to start your server using the `Main.main` function when you manually run your client.