### PR TITLE
Update Phase 4 Git Requirements

### DIFF
--- a/chess/4-database/database.md
+++ b/chess/4-database/database.md
@@ -132,7 +132,7 @@ To pass off this assignment use the course [auto-grading](https://cs240.click/) 
 
 | Category       | Criteria                                                                                                                                                                            |       Points |
 | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----------: |
-| GitHub History | At least 12 GitHub commits evenly spread over the assignment period that demonstrate proof of work                                                                                  | Prerequisite |
+| GitHub History | At least 8 GitHub commits evenly spread over the assignment period that demonstrate proof of work                                                                                   | Prerequisite |
 | Functionality  | All pass off test cases succeed                                                                                                                                                     |          100 |
 | Code Quality   | [Rubric](../code-quality-rubric.md)                                                                                                                                                 |           30 |
 | Unit Tests     | All test cases pass<br/>Each public method on DAO classes has two test cases, one positive test and one negative test<br/>Every test case includes an Assert statement of some type |           25 |


### PR DESCRIPTION
It was decided last semester that having 12 commits for phase 4 was a little much. We have dropped the commit requirement from 12 to 8, which is already being enforced by the autograder. This PR just updates the rubric as well.