### PR TITLE
Javalin Enable Automatic Pings Instruction

### DIFF
--- a/instruction/websocket/example-code/server/SimpleWsEchoServer.java
+++ b/instruction/websocket/example-code/server/SimpleWsEchoServer.java
@@ -5,7 +5,10 @@ public class SimpleWsEchoServer {
         Javalin.create()
                 .get("/echo/{msg}", ctx -> ctx.result("HTTP response: " + ctx.pathParam("msg")))
                 .ws("/ws", ws -> {
-                    ws.onConnect(_ -> System.out.println("Websocket connected"));
+                    ws.onConnect(ctx -> {
+                        ctx.enableAutomaticPings();
+                        System.out.println("Websocket connected");}
+                        );
                     ws.onMessage(ctx -> ctx.send("WebSocket response:" + ctx.message()));
                     ws.onClose(_ -> System.out.println("Websocket closed"));
                 })

--- a/instruction/websocket/example-code/server/WsRequestHandler.java
+++ b/instruction/websocket/example-code/server/WsRequestHandler.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 public class WsRequestHandler implements WsConnectHandler, WsMessageHandler, WsCloseHandler {
     @Override
     public void handleConnect(@NotNull WsConnectContext ctx) {
+        ctx.enableAutomaticPings();
         System.out.println("Websocket connected");
     }
 

--- a/instruction/websocket/websocket.md
+++ b/instruction/websocket/websocket.md
@@ -30,7 +30,10 @@ public class SimpleWsEchoServer {
         Javalin.create()
                 .get("/echo/{msg}", ctx -> ctx.result("HTTP response: " + ctx.pathParam("msg")))
                 .ws("/ws", ws -> {
-                    ws.onConnect(_ -> System.out.println("Websocket connected"));
+                    ws.onConnect(ctx -> {
+                        ctx.enableAutomaticPings();
+                        System.out.println("Websocket connected");
+                    });
                     ws.onMessage(ctx -> ctx.send("WebSocket response:" + ctx.message()));
                     ws.onClose(_ -> System.out.println("Websocket closed"));
                 })
@@ -40,6 +43,12 @@ public class SimpleWsEchoServer {
 ```
 
 This code calls Javalin.create() to create an HTTP server, and then uses a fluent API to chain calls to get, which registers code for handling an HTTP GET request; ws, which registers code for handling WebSocket connections, messages, and closures coming from a peer; and start, which starts the server on the specified port.
+
+## Websocket Timeout
+
+By default, if Javalin has not heard from it's client for 30 seconds, the connection is deemed closed. Once the connection is closed, no messages can be sent. If you want to send something again, you have to open a new connection.
+
+Rather than open a new connection every 30 seconds, we can have Javalin ping it's connections. If a pong is recieved back, then we know the connection is still open. Javalin can be instructed to do this with every connection by calling `context.enableAutomaticPings()`. You'll notice in the above example that this is enabled when the connection is opened.
 
 ## Creating a WebSocket Client Connection
 
@@ -103,32 +112,6 @@ public class WsEchoClient extends Endpoint {
     }
 }
 
-```
-## Websocket Timeout
-
-By default, if Javalin has not heard from it's client for 30 seconds, the connection is deemed closed. Once the connection is closed, no messages can be sent. If you want to send something again, you have to open a new connection.
-
-Rather than open a new connection every 30 seconds, we can have Javalin ping it's connections. If a pong is recieved back, then we know the connection is still open. 
-
-
-```java
-import io.javalin.Javalin;
-
-public class SimpleWsEchoServer {
-    public static void main(String[] args) {
-        Javalin.create()
-                .get("/echo/{msg}", ctx -> ctx.result("HTTP response: " + ctx.pathParam("msg")))
-                .ws("/ws", ws -> {
-                    ws.onConnect(ctx -> {
-                        System.out.println("Websocket connected");
-                        ctx.enableAutomaticPings();
-                    });
-                    ws.onMessage(ctx -> ctx.send("WebSocket response:" + ctx.message()));
-                    ws.onClose(_ -> System.out.println("Websocket closed"));
-                })
-                .start(8080);
-    }
-}
 ```
 
 ## Demonstration code

--- a/instruction/websocket/websocket.md
+++ b/instruction/websocket/websocket.md
@@ -104,6 +104,32 @@ public class WsEchoClient extends Endpoint {
 }
 
 ```
+## Websocket Timeout
+
+By default, if Javalin has not heard from it's client for 30 seconds, the connection is deemed closed. Once the connection is closed, no messages can be sent. If you want to send something again, you have to open a new connection.
+
+Rather than open a new connection every 30 seconds, we can have Javalin ping it's connections. If a pong is recieved back, then we know the connection is still open. 
+
+
+```java
+import io.javalin.Javalin;
+
+public class SimpleWsEchoServer {
+    public static void main(String[] args) {
+        Javalin.create()
+                .get("/echo/{msg}", ctx -> ctx.result("HTTP response: " + ctx.pathParam("msg")))
+                .ws("/ws", ws -> {
+                    ws.onConnect(ctx -> {
+                        System.out.println("Websocket connected");
+                        ctx.enableAutomaticPings();
+                    });
+                    ws.onMessage(ctx -> ctx.send("WebSocket response:" + ctx.message()));
+                    ws.onClose(_ -> System.out.println("Websocket closed"));
+                })
+                .start(8080);
+    }
+}
+```
 
 ## Demonstration code
 


### PR DESCRIPTION
Spark's implementation of WebSocket would keep connections open for 5 minutes. This meant students generally didn't ping their clients to make sure connections were still alive. 

Now that we are migrating to Javalin, the connection timeout is 30 seconds. Thankfully, Javalin makes it super easy to ping it's connections. All you have to do is invoke the `enableAutomaticPings` function on the `context` object passed in. 

Currently, the instructions have a diagram referencing ping/pong, but don't describe how to enable it. @jerodw I know you said you put this code in your slides, but I couldn't find it on the ones linked here. I think it would be valuable to put this in the instructions somewhere. This pull request puts the `enableAutomaticPings` call in the sample echo server. It also has a section right after stating the value of it. 

If you feel like something is missing or inaccurate, please let me know!

Resolves https://github.com/softwareconstruction240/softwareconstruction/issues/285