### PR TITLE
Fixed Schedule link anchor

### DIFF
--- a/.github/structure/_Sidebar.md
+++ b/.github/structure/_Sidebar.md
@@ -1,5 +1,5 @@
 [**Home**](Home)  
-[**Schedule**](Home#outcomes) <!--If structure for schedules is made, they could be moved to wiki-->  
+[**Schedule**](Home#course-schedule) <!--If structure for schedules is made, they could be moved to wiki-->  
 [**Syllabus**](/instruction/syllabus/syllabus.md)  
 [**Pet Shop**](/petshop/petshop.md)  
 


### PR DESCRIPTION
Does as the title says. It linked to the Home page's Outcomes instead of the Course Schedule. This fixes that