### PR TITLE
Wiki improvements

### DIFF
--- a/.github/scripts/rewrite_rules.py
+++ b/.github/scripts/rewrite_rules.py
@@ -3,11 +3,7 @@ This module provides a common place to change the specific information of the re
 to allow its reuse in other repositories as desired.
 """
 import re
-from structure import FilePath, slugify     # pylint: disable=W0611
-
-GHWT_HYPHEN = '‐'
-"""Holds the U+2010 hyphen character, which correctly renders
-as a hyphen when used inside a GitHub Wiki page title"""
+from structure import FilePath, slugify, GHWT_HYPHEN     # pylint: disable=W0611
 
 LINK_BASE_CASES = [r':\/\/', r'^Home#?', r'^tel:.*', r'^mailto:.*', r'^#']
 """List of regex strings that will leave a markdown link unchanged

--- a/.github/scripts/structure.py
+++ b/.github/scripts/structure.py
@@ -53,9 +53,14 @@ class TupleNameMap:
                 self._name_map.get(name))
 
 
+GHWT_HYPHEN = '‐'
+"""Holds the U+2010 hyphen character, which correctly renders
+as a hyphen when used inside a GitHub Wiki page title"""
+
 def slugify(name: str) -> str:
     """Remove filesystem-unfriendly chars"""
     name = name.strip()
+    name = re.sub(r'[:]', f' {GHWT_HYPHEN}', name)
     name = re.sub(r'[\\/:"*?<>|]+', '', name)
     name = re.sub(r'\s+', '-', name)
     return name

--- a/.github/structure/_Sidebar.md
+++ b/.github/structure/_Sidebar.md
@@ -1,7 +1,6 @@
 [**Home**](Home)  
 [**Schedule**](Home#course-schedule) <!--If structure for schedules is made, they could be moved to wiki-->  
 [**Syllabus**](/instruction/syllabus/syllabus.md)  
-[**Pet Shop**](/petshop/petshop.md)  
 
 [**Auto-Grader**](https://cs240.click)  
 [**Help Queue**](https://help.cs240.click)  
@@ -23,6 +22,7 @@
 ## Instruction
 
 [**Instructional topics**](/instruction/modules.md)  
+[**Pet Shop**](/petshop/petshop.md)  
 <!--Write out topics in either alphabetical or instruction order, or only parent links within modules.md-->
 
 <!--Files not listed:

--- a/.github/structure/_Sidebar.md
+++ b/.github/structure/_Sidebar.md
@@ -2,21 +2,21 @@
 [**Schedule**](Home#course-schedule) <!--If structure for schedules is made, they could be moved to wiki-->  
 [**Syllabus**](/instruction/syllabus/syllabus.md)  
 
-[**Auto-Grader**](https://cs240.click)  
+[**Autograder**](https://cs240.click)  
 [**Help Queue**](https://help.cs240.click)  
 
 ## Chess
 
-[**Chess Application**](/chess/chess.md)  
-<!--Chess Assignments-->
+[**Chess Overview**](/chess/chess.md)  
+
 [**GitHub Repository**](/chess/chess-github-repository/chess-github-repository.md)  
-[**Phase 0**](/chess/0-chess-moves/chess-moves.md)  
-[**Phase 1**](/chess/1-chess-game/chess-game.md)  
-[**Phase 2**](/chess/2-server-design/server-design.md)  
-[**Phase 3**](/chess/3-web-api/web-api.md)  
-[**Phase 4**](/chess/4-database/database.md)  
-[**Phase 5**](/chess/5-pregame/pregame.md)  
-[**Phase 6**](/chess/6-gameplay/gameplay.md)  
+[**Phase 0: Chess Moves**](/chess/0-chess-moves/chess-moves.md)  
+[**Phase 1: Chess Game**](/chess/1-chess-game/chess-game.md)  
+[**Phase 2: Server Design**](/chess/2-server-design/server-design.md)  
+[**Phase 3: Web API**](/chess/3-web-api/web-api.md)  
+[**Phase 4: Database**](/chess/4-database/database.md)  
+[**Phase 5: Pregame**](/chess/5-pregame/pregame.md)  
+[**Phase 6: Gameplay**](/chess/6-gameplay/gameplay.md)  
 <!--I don't think we need to link to getting started directly through here?-->
 
 ## Instruction


### PR DESCRIPTION
Modifies the script somewhat such that:
- Colons in the Title are replaced with Hyphens so GitHub renders the separator
- Updates some titles in the Sidebar to be more accurate/complete to what they are
- Moved Pet Shop link in the sidebar to instruction header for balance and purpose

Closes #304 

I could not achieve external page links due to GitHub limitations, unfortunately.

I'm ok if this isn't merged immediately but I think this is the final sidebar update for me at least in a while.