### PR TITLE
Fix schedule relative link rewrite

### DIFF
--- a/.github/scripts/rewrite.py
+++ b/.github/scripts/rewrite.py
@@ -62,9 +62,8 @@ def main(root: str, code_base: str):
                 new_base = edited_map.get(dirname, info.parent, basename)
                 if new_base:
                     return re.sub(clean_ext_pattern, '', new_base, flags=re.IGNORECASE)
-                return link_to_codebase()
-            case _:
-                return link_to_codebase()
+        
+        return link_to_codebase()
 
     def rewrite_line(line: str, info: ContentFilePath) -> str:
         def repl(m: re.Match[str]) -> str:

--- a/.github/scripts/rewrite.py
+++ b/.github/scripts/rewrite.py
@@ -4,12 +4,13 @@ import os
 import re
 from structure import ContentFilePath, FilePath, TupleNameMap, slugify
 from rewrite_rules import (LINK_BASE_CASES, EMBED_EXTS, EDIT_FILE_EXTS,
-    wiki_page_title, extract_title_and_body)
+                           wiki_page_title, extract_title_and_body)
 
 
 def get_ext(path: str):
     """Get the file extension, if present"""
     return path.lower().rsplit('.', 1)[-1] if '.' in path else ''
+
 
 def find_files_with_exts(root: str, *exts: str):
     """Yield FilePaths for files of the given extensions."""
@@ -17,6 +18,7 @@ def find_files_with_exts(root: str, *exts: str):
         for f in files:
             if get_ext(f) in exts:
                 yield FilePath(path_from_root, f)
+
 
 def main(root: str, code_base: str):
     mapping: dict[str, ContentFilePath] = {}
@@ -81,6 +83,7 @@ def main(root: str, code_base: str):
 
         with open(info.full_path, 'w', encoding='utf-8') as f:
             f.writelines(new_body)
+
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:

--- a/.github/scripts/rewrite_rules.py
+++ b/.github/scripts/rewrite_rules.py
@@ -3,7 +3,7 @@ This module provides a common place to change the specific information of the re
 to allow its reuse in other repositories as desired.
 """
 import re
-from structure import FilePath, slugify, GHWT_HYPHEN     # pylint: disable=W0611
+from structure import FilePath, slugify, GHWT_HYPHEN  # pylint: disable=W0611
 
 LINK_BASE_CASES = [r':\/\/', r'^Home#?', r'^tel:.*', r'^mailto:.*', r'^#']
 """List of regex strings that will leave a markdown link unchanged
@@ -14,6 +14,7 @@ EMBED_EXTS = {'png', 'gif', 'jpg', 'jpeg', 'svg', 'webp', 'uml', 'mp4', 'mov', '
 
 EDIT_FILE_EXTS = {'md'}
 """File extensions that will be modified by the script."""
+
 
 def wiki_page_title(title: str | None, body: list[str], file_path: FilePath) -> str:
     # pylint: disable=W0613
@@ -31,6 +32,7 @@ def wiki_page_title(title: str | None, body: list[str], file_path: FilePath) -> 
             return f"{title} {GHWT_HYPHEN} Phase {phase_dir.group(1)}.md"
         return title + '.md'
     return file_path.filename
+
 
 def extract_title_and_body(path: str) -> tuple[str | None, list[str]]:
     """

--- a/.github/scripts/structure.py
+++ b/.github/scripts/structure.py
@@ -57,6 +57,7 @@ GHWT_HYPHEN = '‐'
 """Holds the U+2010 hyphen character, which correctly renders
 as a hyphen when used inside a GitHub Wiki page title"""
 
+
 def slugify(name: str) -> str:
     """Remove filesystem-unfriendly chars"""
     name = name.strip()

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Used to store files while they're modified for Wiki.
 docs
+**pycache**


### PR DESCRIPTION
When the schedule links were changed to be relative, a couple of things broke for the Wiki Sync, which this PR addresses which makes any relative link that isn't in the wiki link back to the original file in the wiki page.