### PR TITLE
Made Submission Section Programming Exam Instructions

### DIFF
--- a/instruction/programming-exam/programming-exam.md
+++ b/instruction/programming-exam/programming-exam.md
@@ -97,7 +97,7 @@ You may not open other tabs or access other information during the exam. This is
 
 If you want to make handwritten notes while working, have a blank sheet of paper ready and show it to the camera at the start of the exam.
 
-## Submission/Uploads
+### Submission/Uploads
 
 When planning your time, allow yourself at least 20 minutes at the end of the exam to submit everything.
 


### PR DESCRIPTION
A student noticed that the programming exam instructions Canvas quiz refers to a "Submissions/Uploads" header that previously existed in Canvas but not on GitHub. Looking back at a previous semester I was a TA for to see what was previously under that header, I noticed that the content itself exists in the instructions on GitHub but the not in its own "Submission/Uploads" section. I just added a header to the content, so it is easier to go back to and refer to those instructions specifically.