### PR TITLE
New Phase 3 TA Tip

### DIFF
--- a/instruction/chess-tips/chess-tips.md
+++ b/instruction/chess-tips/chess-tips.md
@@ -100,17 +100,13 @@ Return new Gson().toJson(Map.of(“message”, ex.getMessage()));
 
 ## Autograder doesn't compile my project - package com.fasterxml.jackson.core does not exist / expected: <401> but was: <500>
 
-If your code runs on your local machine, but your code will not compile, or you receive 500 HTTP status codes, one potential reason is that your project has added the jackson dependency, which the autograder does not use. You might be doing something like:
+If your code fails to compile in the autograder or you receive 500 HTTP status codes but runs fine on your local machine, one potential reason is that your project is using dependencies beyond what is used in the specifications of the project. This will cause problems because the autograder might not be using those dependencies. One specific dependency you might be using is jackson, which would be reflected if your handlers or servers are doing something similar to the following:
 
 ```java
 ctx.json(registerResponse);
 ```
 
-The autograder expects you to use specific dependencies, one of which is Gson. Serializing your response with Gson rather than with Jackson will ensure that your project isn't using any dependencies that are undefined to the autograder. In this example:
-
-```java
-ctx.result(gson.toJson(registerResponse));
-```
+The autograder expects you to use specific dependencies, one of which is Gson. Serializing your response with Gson rather than with Jackson will ensure that your project isn't using any dependencies that are undefined to the autograder.
 
 ## How do I read the authToken from an HTTP request?
 

--- a/instruction/chess-tips/chess-tips.md
+++ b/instruction/chess-tips/chess-tips.md
@@ -98,6 +98,12 @@ Or if this problem is happening with error handling, try to return the error in 
 Return new Gson().toJson(Map.of(“message”, ex.getMessage()));
 ```
 
+## IntelliJ is giving me errors and is asking me to add the jackson dependency to my project
+
+It is possible that javalin will suggest that you use the jackson dependency to deal with serialization. If you see this suggestion, it could mean that you are not properly serializing your response or that your endpoint is not returning what the client expects. Check your return types and what you are sending across the server to the client and make sure it matches your sequence diagram and the project specs. 
+
+In this project, **you should not add any additional dependencies** beyond what the project instruction tells you to add. 
+
 ## Autograder doesn't compile my project - package com.fasterxml.jackson.databind does not exist / expected: <401> but was: <500>
 
 If your code fails to compile in the autograder or you receive 500 HTTP status codes but runs fine on your local machine, one potential reason is that your project is using dependencies beyond what is used in the specifications of the project. This will cause problems because the autograder might not be using those dependencies. One specific dependency you might be using is jackson, which would be reflected if your handler or server is doing something similar to the following:

--- a/instruction/chess-tips/chess-tips.md
+++ b/instruction/chess-tips/chess-tips.md
@@ -98,15 +98,15 @@ Or if this problem is happening with error handling, try to return the error in 
 Return new Gson().toJson(Map.of(“message”, ex.getMessage()));
 ```
 
-## Autograder doesn't compile my project - package com.fasterxml.jackson.core does not exist / expected: <401> but was: <500>
+## Autograder doesn't compile my project - package com.fasterxml.jackson.databind does not exist / expected: <401> but was: <500>
 
-If your code fails to compile in the autograder or you receive 500 HTTP status codes but runs fine on your local machine, one potential reason is that your project is using dependencies beyond what is used in the specifications of the project. This will cause problems because the autograder might not be using those dependencies. One specific dependency you might be using is jackson, which would be reflected if your handlers or servers are doing something similar to the following:
+If your code fails to compile in the autograder or you receive 500 HTTP status codes but runs fine on your local machine, one potential reason is that your project is using dependencies beyond what is used in the specifications of the project. This will cause problems because the autograder might not be using those dependencies. One specific dependency you might be using is jackson, which would be reflected if your handler or server is doing something similar to the following:
 
 ```java
 ctx.json(registerResponse);
 ```
 
-The autograder expects you to use specific dependencies, one of which is Gson. Serializing your response with Gson rather than with Jackson will ensure that your project isn't using any dependencies that are undefined to the autograder.
+The autograder expects you to use specific dependencies, one of which is Gson. Serializing your response with Gson rather than with Jackson will ensure that your project isn't using any dependencies that are undefined to the autograder. Feel free to look at [PetShop's Server class](https://github.com/softwareconstruction240/softwareconstruction/blob/main/petshop/server/src/main/server/PetServer.java) and examine how serialization is done there.
 
 ## How do I read the authToken from an HTTP request?
 

--- a/instruction/chess-tips/chess-tips.md
+++ b/instruction/chess-tips/chess-tips.md
@@ -98,6 +98,20 @@ Or if this problem is happening with error handling, try to return the error in 
 Return new Gson().toJson(Map.of(“message”, ex.getMessage()));
 ```
 
+## Autograder doesn't compile my project - package com.fasterxml.jackson.core does not exist
+
+If your code runs on your local machine, but your code will not compile, or you receive 500 HTTP status codes, one potential reason is that your project has added the jackson dependency, which the autograder does not use. You might be doing something like:
+
+```java
+ctx.json(registerResponse);
+```
+
+The autograder expects you to use specific dependencies, one of which is Gson. Serializing your response with Gson rather than with Jackson will ensure that your project isn't using any dependencies that are undefined to the autograder. In this example:
+
+```java
+ctx.result(gson.toJson(registerResponse));
+```
+
 ## How do I read the authToken from an HTTP request?
 
 Refer to the [Web API](https://github.com/softwareconstruction240/softwareconstruction/blob/main/instruction/web-api/web-api.md#http-headers) instruction.

--- a/instruction/chess-tips/chess-tips.md
+++ b/instruction/chess-tips/chess-tips.md
@@ -98,7 +98,7 @@ Or if this problem is happening with error handling, try to return the error in 
 Return new Gson().toJson(Map.of(“message”, ex.getMessage()));
 ```
 
-## Autograder doesn't compile my project - package com.fasterxml.jackson.core does not exist
+## Autograder doesn't compile my project - package com.fasterxml.jackson.core does not exist / expected: <401> but was: <500>
 
 If your code runs on your local machine, but your code will not compile, or you receive 500 HTTP status codes, one potential reason is that your project has added the jackson dependency, which the autograder does not use. You might be doing something like:
 


### PR DESCRIPTION
Closes #356 

Some students run into issues if they serialize their data using dependencies other than Gson, as those dependencies are not recognized by the autograder. This causes difficult issues for students when their code runs fine locally but won't compile or gives unexpected errors when run in the autograder, which is the reason I considered it requisite to add a TA tip to help students avoid this problem.