### PR TITLE
Added case for full links directly to repo

### DIFF
--- a/.github/scripts/rewrite.py
+++ b/.github/scripts/rewrite.py
@@ -44,6 +44,9 @@ def main(root: str, code_base: str):
     clean_ext_pattern = r'\.(' + '|'.join(EDIT_FILE_EXTS) + r')$'
 
     def extract_new_link(info: ContentFilePath, path_part: str) -> str:
+        if path_part.startswith(code_base):
+            path_part = path_part.removeprefix(code_base.rstrip('/'))
+
         dirname = os.path.basename(os.path.dirname(path_part))
         basename = os.path.basename(path_part)
 


### PR DESCRIPTION
Small modification to the wiki maintainer scripts, where links that don't link with a relative path, but still link to the repository, are treated as their relative path counterpart, so the script doesn't ignore it.

Should only really affect the schedule wiki page but it's a useful edge case to cover anyway